### PR TITLE
feat: add manifest/GeoJSON persistence for web app consolidation

### DIFF
--- a/src/omero_annotate_ai/core/annotation_config.py
+++ b/src/omero_annotate_ai/core/annotation_config.py
@@ -1,5 +1,6 @@
 """Configuration management for OMERO AI annotation workflows."""
 
+import json
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -997,6 +998,36 @@ class AnnotationConfig(BaseModel):
         # Not a file path - treat as YAML string
         config_dict = yaml.safe_load(str(yaml_source))
         return cls.from_dict(config_dict)
+
+    def to_json(self, **kwargs) -> str:
+        """Serialize to JSON string.
+
+        Uses the same dict representation as to_dict(), ensuring
+        consistency with YAML serialization.
+        """
+        return json.dumps(self.to_dict(), default=str, **kwargs)
+
+    @classmethod
+    def from_json(cls, json_source: Union[str, Path, dict]) -> "AnnotationConfig":
+        """Load from JSON string, file path, or dict.
+
+        Args:
+            json_source: JSON string, Path to .json file, or dict.
+
+        Returns:
+            Hydrated AnnotationConfig instance.
+        """
+        if isinstance(json_source, dict):
+            return cls.from_dict(json_source)
+        if isinstance(json_source, Path) or (
+            isinstance(json_source, str) and not json_source.strip().startswith("{")
+        ):
+            path = Path(json_source)
+            with open(path) as f:
+                data = json.load(f)
+            return cls.from_dict(data)
+        data = json.loads(json_source)
+        return cls.from_dict(data)
 
 
 class ValidationIssue(BaseModel):

--- a/src/omero_annotate_ai/core/annotation_config.py
+++ b/src/omero_annotate_ai/core/annotation_config.py
@@ -31,6 +31,28 @@ def _str_to_optional_int(value: str) -> Optional[int]:
 # Sub-models for the configuration
 
 
+class ChannelPresentation(BaseModel):
+    """How an image channel is presented for annotation/training.
+
+    Records the exact rendering parameters used when annotating,
+    ensuring reproducibility and correct normalization for training.
+    Lives at the image level — all patches share the same normalization.
+    """
+
+    channel_index: int
+    visible: bool = True
+    contrast_start: float
+    contrast_end: float
+    color: str = "#FFFFFF"
+
+
+class FeatureType(BaseModel):
+    """An annotation class (e.g. cell, nucleus, background)."""
+
+    name: str
+    color: str  # hex color, e.g. "#FF0000"
+
+
 class ImageAnnotation(BaseModel):
     """Individual image annotation record for tracking processing state"""
 
@@ -84,6 +106,12 @@ class ImageAnnotation(BaseModel):
     )
     schema_attachment_id: Optional[int] = Field(
         default=None, description="OMERO schema attachment ID"
+    )
+
+    # Channel presentation (how the image was displayed during annotation)
+    channel_presentation: Optional[List[ChannelPresentation]] = Field(
+        default=None,
+        description="Channel rendering parameters at annotation time (image-level, shared across patches)",
     )
 
     def mark_processed(
@@ -608,6 +636,10 @@ class AnnotationConfig(BaseModel):
         default=None, description="Code repository URL"
     )
     tags: List[str] = Field(default_factory=list, description="Classification tags")
+    feature_types: List[FeatureType] = Field(
+        default_factory=list,
+        description="Annotation classes (e.g. cell, nucleus) with display colors",
+    )
 
     def model_dump(self, **kwargs):
         """Override model_dump to handle Path serialization"""

--- a/src/omero_annotate_ai/omero/omero_functions.py
+++ b/src/omero_annotate_ai/omero/omero_functions.py
@@ -1,5 +1,9 @@
 """OMERO integration functions for micro-SAM workflows."""
 
+import json
+import os
+import random
+import string
 import tempfile
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -24,6 +28,268 @@ from ..core.annotation_config import AnnotationConfig
 
 # Namespace for annotation config file annotations
 CONFIG_NS = "openmicroscopy.org/omero/annotate/config"
+
+# Namespace prefixes for JSON manifest and GeoJSON storage
+MANIFEST_NS_PREFIX = "omero.biomero.manifest."
+GEOJSON_NS_PREFIX = "omero.biomero.annotations."
+
+
+def generate_set_id() -> str:
+    """Generate a unique set_id: timestamp with milliseconds + 4-char random suffix."""
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")[:20]
+    suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+    return f"{ts}_{suffix}"
+
+
+def manifest_namespace(set_id: str) -> str:
+    """Return the OMERO namespace for a manifest FileAnnotation."""
+    return f"{MANIFEST_NS_PREFIX}{set_id}"
+
+
+def geojson_namespace(set_id: str) -> str:
+    """Return the OMERO namespace for GeoJSON FileAnnotations."""
+    return f"{GEOJSON_NS_PREFIX}{set_id}"
+
+
+def save_manifest_to_omero(
+    conn, config, container_type: str, container_id: int, set_id: str
+) -> int:
+    """Save AnnotationConfig as a JSON FileAnnotation on a container.
+
+    Replaces any existing manifest with the same set_id namespace.
+    Returns the FileAnnotation ID.
+    """
+    ns = manifest_namespace(set_id)
+    container = conn.getObject(container_type.capitalize(), container_id)
+    if not container:
+        raise ValueError(f"{container_type} {container_id} not found")
+
+    # Remove existing manifest with same namespace
+    to_delete = []
+    for ann in container.listAnnotations():
+        if hasattr(ann, "getNs") and ann.getNs() == ns:
+            to_delete.append(ann.getId())
+    if to_delete:
+        try:
+            conn.deleteObjects("Annotation", to_delete, wait=True)
+        except Exception:
+            pass
+
+    # Write JSON to temp file and upload
+    filename = f"{config.name}_{set_id}.json"
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", prefix=filename.replace(".json", "_"), delete=False
+    ) as tmp:
+        tmp.write(config.to_json())
+        tmp_path = tmp.name
+
+    try:
+        file_ann = conn.createFileAnnfromLocalFile(
+            tmp_path, mimetype="application/json", ns=ns
+        )
+        container.linkAnnotation(file_ann)
+        return file_ann.getId()
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+def load_manifest_from_omero(conn, container_type: str, container_id: int, set_id: str):
+    """Load an AnnotationConfig manifest by set_id from a container.
+
+    Returns None if not found.
+    """
+    ns = manifest_namespace(set_id)
+    container = conn.getObject(container_type.capitalize(), container_id)
+    if not container:
+        return None
+
+    for ann in container.listAnnotations():
+        if hasattr(ann, "getNs") and ann.getNs() == ns:
+            try:
+                content = b"".join(ann.getFileInChunks())
+                data = json.loads(content)
+                return AnnotationConfig.from_json(data)
+            except Exception:
+                continue
+    return None
+
+
+def list_manifests_from_omero(conn, container_type: str, container_id: int) -> list:
+    """List all manifest summaries on a container.
+
+    Returns list of dicts: {set_id, name, created, progress, annotation_id}.
+    """
+    container = conn.getObject(container_type.capitalize(), container_id)
+    if not container:
+        return []
+
+    manifests = []
+    for ann in container.listAnnotations():
+        ns = getattr(ann, "getNs", lambda: None)()
+        if ns and ns.startswith(MANIFEST_NS_PREFIX):
+            set_id = ns[len(MANIFEST_NS_PREFIX):]
+            try:
+                content = b"".join(ann.getFileInChunks())
+                data = json.loads(content)
+                config = AnnotationConfig.from_json(data)
+                progress = config.get_progress_summary()
+                manifests.append({
+                    "set_id": set_id,
+                    "name": config.name,
+                    "created": str(config.created),
+                    "progress": progress,
+                    "annotation_id": ann.getId(),
+                })
+            except Exception:
+                continue
+    return manifests
+
+
+def delete_manifest_from_omero(
+    conn, container_type: str, container_id: int, set_id: str
+) -> bool:
+    """Delete a manifest and all associated GeoJSON FileAnnotations."""
+    # Load manifest to find image IDs
+    config = load_manifest_from_omero(conn, container_type, container_id, set_id)
+    if config:
+        image_ids = {ann.image_id for ann in config.annotations}
+        ns = geojson_namespace(set_id)
+        for image_id in image_ids:
+            image = conn.getObject("Image", image_id)
+            if not image:
+                continue
+            to_delete = [
+                a.getId() for a in image.listAnnotations()
+                if hasattr(a, "getNs") and a.getNs() == ns
+            ]
+            if to_delete:
+                try:
+                    conn.deleteObjects("Annotation", to_delete, wait=True)
+                except Exception:
+                    pass
+
+    # Delete the manifest itself
+    container = conn.getObject(container_type.capitalize(), container_id)
+    if not container:
+        return False
+    mns = manifest_namespace(set_id)
+    to_delete = [
+        a.getId() for a in container.listAnnotations()
+        if hasattr(a, "getNs") and a.getNs() == mns
+    ]
+    if to_delete:
+        try:
+            conn.deleteObjects("Annotation", to_delete, wait=True)
+        except Exception:
+            return False
+    return True
+
+
+def merge_geojson_patches(existing: dict, new: dict) -> dict:
+    """Merge new GeoJSON features into existing, replacing features for the same patch.
+
+    Features are matched by their patch property (x, y, width, height).
+    Features without a patch property are treated as full-image and always replaced.
+    Channel presentation is taken from the new GeoJSON (latest truth).
+    """
+    result = {
+        "type": "FeatureCollection",
+        "channel_presentation": new.get("channel_presentation", existing.get("channel_presentation", [])),
+        "features": [],
+    }
+
+    def patch_key(feature):
+        p = feature.get("properties", {}).get("patch")
+        if p:
+            return (p["x"], p["y"], p["width"], p["height"])
+        return None
+
+    new_patches = {}
+    for f in new.get("features", []):
+        key = patch_key(f)
+        if key not in new_patches:
+            new_patches[key] = []
+        new_patches[key].append(f)
+
+    # Keep existing features whose patch is NOT in the new set
+    for f in existing.get("features", []):
+        key = patch_key(f)
+        if key not in new_patches:
+            result["features"].append(f)
+
+    # Add all new features
+    for features in new_patches.values():
+        result["features"].extend(features)
+
+    return result
+
+
+def save_geojson_to_omero(conn, image_id: int, geojson: dict, set_id: str) -> int:
+    """Save GeoJSON FeatureCollection as FileAnnotation on an image.
+
+    If a GeoJSON for this set_id already exists, merges patch features.
+    Returns the FileAnnotation ID.
+    """
+    ns = geojson_namespace(set_id)
+    image = conn.getObject("Image", image_id)
+    if not image:
+        raise ValueError(f"Image {image_id} not found")
+
+    # Load existing and merge if present
+    existing = load_geojson_from_omero(conn, image_id, set_id)
+    if existing:
+        geojson = merge_geojson_patches(existing, geojson)
+
+    # Remove old FileAnnotation
+    to_delete = []
+    for ann in image.listAnnotations():
+        if hasattr(ann, "getNs") and ann.getNs() == ns:
+            to_delete.append(ann.getId())
+    if to_delete:
+        try:
+            conn.deleteObjects("Annotation", to_delete, wait=True)
+        except Exception:
+            pass
+
+    # Write and upload
+    image_name = image.getName() or f"image_{image_id}"
+    filename = f"{image_name}_{set_id}.geojson"
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".geojson", prefix=filename.replace(".geojson", "_"), delete=False
+    ) as tmp:
+        json.dump(geojson, tmp)
+        tmp_path = tmp.name
+
+    try:
+        file_ann = conn.createFileAnnfromLocalFile(
+            tmp_path, mimetype="application/json", ns=ns
+        )
+        image.linkAnnotation(file_ann)
+        return file_ann.getId()
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+def load_geojson_from_omero(conn, image_id: int, set_id: str):
+    """Load GeoJSON FeatureCollection by set_id namespace from an image.
+
+    Returns None if not found.
+    """
+    ns = geojson_namespace(set_id)
+    image = conn.getObject("Image", image_id)
+    if not image:
+        return None
+
+    for ann in image.listAnnotations():
+        if hasattr(ann, "getNs") and ann.getNs() == ns:
+            try:
+                content = b"".join(ann.getFileInChunks())
+                return json.loads(content)
+            except Exception:
+                continue
+    return None
 
 
 # =============================================================================

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -791,3 +791,77 @@ class TestFeatureType:
         data = ft.model_dump()
         ft2 = FeatureType(**data)
         assert ft == ft2
+
+
+@pytest.mark.unit
+class TestAnnotationConfigJSON:
+    """Tests for JSON serialization of AnnotationConfig."""
+
+    def _make_config(self):
+        from omero_annotate_ai.core.annotation_config import (
+            AnnotationConfig, FeatureType, ChannelPresentation,
+            StudyContext, DatasetInfo, AnnotationMethodology,
+            SpatialCoverage, TrainingConfig, AIModelConfig,
+            WorkflowConfig, OutputConfig, OMEROConfig, ImageAnnotation,
+        )
+        config = AnnotationConfig(
+            name="test_workflow",
+            study=StudyContext(title="Test", description="Test study"),
+            dataset=DatasetInfo(source_description="test"),
+            annotation_methodology=AnnotationMethodology(annotation_criteria="test"),
+            spatial_coverage=SpatialCoverage(channels=[0], timepoints=[0], z_slices=[0]),
+            training=TrainingConfig(),
+            ai_model=AIModelConfig(),
+            workflow=WorkflowConfig(),
+            output=OutputConfig(),
+            omero=OMEROConfig(container_type="dataset", container_id=1),
+            feature_types=[FeatureType(name="cell", color="#FF0000")],
+        )
+        ann = ImageAnnotation(image_id=1, image_name="img1")
+        ann.channel_presentation = [
+            ChannelPresentation(channel_index=0, contrast_start=100, contrast_end=4500, color="#00FF00")
+        ]
+        config.annotations.append(ann)
+        return config
+
+    def test_to_json_returns_valid_json(self):
+        import json
+        config = self._make_config()
+        json_str = config.to_json()
+        data = json.loads(json_str)
+        assert data["name"] == "test_workflow"
+        assert len(data["feature_types"]) == 1
+        assert data["feature_types"][0]["name"] == "cell"
+
+    def test_from_json_string(self):
+        config = self._make_config()
+        json_str = config.to_json()
+        loaded = type(config).from_json(json_str)
+        assert loaded.name == config.name
+        assert len(loaded.feature_types) == 1
+        assert loaded.feature_types[0].name == "cell"
+        assert len(loaded.annotations) == 1
+        assert loaded.annotations[0].channel_presentation[0].contrast_start == 100
+
+    def test_from_json_dict(self):
+        import json
+        config = self._make_config()
+        data = json.loads(config.to_json())
+        loaded = type(config).from_json(data)
+        assert loaded.name == config.name
+
+    def test_from_json_file(self):
+        import tempfile
+        from pathlib import Path
+        config = self._make_config()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(config.to_json())
+            f.flush()
+            loaded = type(config).from_json(Path(f.name))
+        assert loaded.name == config.name
+
+    def test_round_trip_preserves_all_fields(self):
+        config = self._make_config()
+        json_str = config.to_json()
+        loaded = type(config).from_json(json_str)
+        assert config.to_dict() == loaded.to_dict()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -743,3 +743,51 @@ class TestAnnotationValidation:
 
         with pytest.raises(ValueError, match="inconsistent with current config"):
             pipeline.define_annotation_schema(images_list=[])
+
+
+@pytest.mark.unit
+class TestChannelPresentation:
+    """Tests for ChannelPresentation model."""
+
+    def test_create_with_required_fields(self):
+        from omero_annotate_ai.core.annotation_config import ChannelPresentation
+        cp = ChannelPresentation(channel_index=0, contrast_start=100.0, contrast_end=4500.0)
+        assert cp.channel_index == 0
+        assert cp.visible is True
+        assert cp.contrast_start == 100.0
+        assert cp.contrast_end == 4500.0
+        assert cp.color == "#FFFFFF"
+
+    def test_create_with_all_fields(self):
+        from omero_annotate_ai.core.annotation_config import ChannelPresentation
+        cp = ChannelPresentation(
+            channel_index=1, visible=False,
+            contrast_start=0.0, contrast_end=255.0, color="#00FF00"
+        )
+        assert cp.visible is False
+        assert cp.color == "#00FF00"
+
+    def test_serialization_round_trip(self):
+        from omero_annotate_ai.core.annotation_config import ChannelPresentation
+        cp = ChannelPresentation(channel_index=0, contrast_start=100.0, contrast_end=4500.0, color="#FF0000")
+        data = cp.model_dump()
+        cp2 = ChannelPresentation(**data)
+        assert cp == cp2
+
+
+@pytest.mark.unit
+class TestFeatureType:
+    """Tests for FeatureType model."""
+
+    def test_create(self):
+        from omero_annotate_ai.core.annotation_config import FeatureType
+        ft = FeatureType(name="cell", color="#FF0000")
+        assert ft.name == "cell"
+        assert ft.color == "#FF0000"
+
+    def test_serialization_round_trip(self):
+        from omero_annotate_ai.core.annotation_config import FeatureType
+        ft = FeatureType(name="nucleus", color="#00FF00")
+        data = ft.model_dump()
+        ft2 = FeatureType(**data)
+        assert ft == ft2

--- a/tests/test_omero_functions.py
+++ b/tests/test_omero_functions.py
@@ -484,3 +484,164 @@ class TestListAnnotationTablesSortsByCreated:
         assert result[0]["name"] == "new_table"
         assert result[1]["name"] == "mid_table"
         assert result[2]["name"] == "old_table"
+
+
+# =============================================================================
+# Manifest and GeoJSON persistence tests
+# =============================================================================
+
+import json
+from omero_annotate_ai.omero.omero_functions import (
+    generate_set_id, manifest_namespace, geojson_namespace,
+    save_manifest_to_omero, load_manifest_from_omero,
+    list_manifests_from_omero, delete_manifest_from_omero,
+    save_geojson_to_omero, load_geojson_from_omero, merge_geojson_patches,
+)
+from omero_annotate_ai.core.annotation_config import (
+    AnnotationConfig, StudyContext, DatasetInfo, AnnotationMethodology,
+    SpatialCoverage, TrainingConfig, AIModelConfig, WorkflowConfig,
+    OutputConfig, OMEROConfig, FeatureType, ImageAnnotation, ChannelPresentation,
+)
+
+
+def _make_test_config():
+    return AnnotationConfig(
+        name="test_workflow",
+        study=StudyContext(title="Test", description="Test"),
+        dataset=DatasetInfo(source_description="test"),
+        annotation_methodology=AnnotationMethodology(annotation_criteria="test"),
+        spatial_coverage=SpatialCoverage(channels=[0], timepoints=[0], z_slices=[0]),
+        training=TrainingConfig(),
+        ai_model=AIModelConfig(),
+        workflow=WorkflowConfig(),
+        output=OutputConfig(),
+        omero=OMEROConfig(container_type="dataset", container_id=1),
+        feature_types=[FeatureType(name="cell", color="#FF0000")],
+        annotations=[ImageAnnotation(image_id=1, image_name="img1")],
+    )
+
+
+@pytest.mark.unit
+class TestManifestPersistence:
+    """Tests for JSON manifest save/load/list/delete on OMERO."""
+
+    def test_generate_set_id_is_unique(self):
+        ids = {generate_set_id() for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_manifest_namespace(self):
+        assert manifest_namespace("abc123") == "omero.biomero.manifest.abc123"
+
+    def test_geojson_namespace(self):
+        assert geojson_namespace("abc123") == "omero.biomero.annotations.abc123"
+
+    def test_load_manifest_from_omero(self):
+        config = _make_test_config()
+        json_bytes = config.to_json().encode("utf-8")
+
+        file_ann = MagicMock()
+        file_ann.getNs.return_value = manifest_namespace("test_set")
+        file_ann.getFileInChunks.return_value = [json_bytes]
+
+        dataset = MagicMock()
+        dataset.listAnnotations.return_value = [file_ann]
+        conn = MagicMock()
+        conn.getObject.return_value = dataset
+
+        loaded = load_manifest_from_omero(conn, "dataset", 1, "test_set")
+        assert loaded is not None
+        assert loaded.name == "test_workflow"
+        assert len(loaded.feature_types) == 1
+
+    def test_load_manifest_not_found(self):
+        dataset = MagicMock()
+        dataset.listAnnotations.return_value = []
+        conn = MagicMock()
+        conn.getObject.return_value = dataset
+
+        result = load_manifest_from_omero(conn, "dataset", 1, "nonexistent")
+        assert result is None
+
+    def test_list_manifests_from_omero(self):
+        config = _make_test_config()
+        json_bytes = config.to_json().encode("utf-8")
+
+        file_ann = MagicMock()
+        file_ann.getNs.return_value = manifest_namespace("set_001")
+        file_ann.getFileInChunks.return_value = [json_bytes]
+        file_ann.getId.return_value = 10
+
+        dataset = MagicMock()
+        dataset.listAnnotations.return_value = [file_ann]
+        conn = MagicMock()
+        conn.getObject.return_value = dataset
+
+        manifests = list_manifests_from_omero(conn, "dataset", 1)
+        assert len(manifests) == 1
+        assert manifests[0]["set_id"] == "set_001"
+        assert manifests[0]["name"] == "test_workflow"
+
+
+@pytest.mark.unit
+class TestGeoJSONPersistence:
+    """Tests for GeoJSON save/load and patch merging."""
+
+    def _make_geojson(self, patch=None):
+        feature = {
+            "type": "Feature",
+            "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]]},
+            "properties": {"objectType": "annotation", "featureType": "cell", "plane": {"c": 0, "z": 0, "t": 0}},
+        }
+        if patch:
+            feature["properties"]["patch"] = patch
+        return {
+            "type": "FeatureCollection",
+            "channel_presentation": [{"channel_index": 0, "visible": True, "contrast_start": 0, "contrast_end": 255, "color": "#FFFFFF"}],
+            "features": [feature],
+        }
+
+    def test_load_geojson_from_omero(self):
+        geojson = self._make_geojson()
+        json_bytes = json.dumps(geojson).encode("utf-8")
+
+        file_ann = MagicMock()
+        file_ann.getNs.return_value = geojson_namespace("set_001")
+        file_ann.getFileInChunks.return_value = [json_bytes]
+
+        image = MagicMock()
+        image.listAnnotations.return_value = [file_ann]
+        conn = MagicMock()
+        conn.getObject.return_value = image
+
+        loaded = load_geojson_from_omero(conn, 1, "set_001")
+        assert loaded is not None
+        assert loaded["type"] == "FeatureCollection"
+        assert len(loaded["features"]) == 1
+
+    def test_load_geojson_not_found(self):
+        image = MagicMock()
+        image.listAnnotations.return_value = []
+        conn = MagicMock()
+        conn.getObject.return_value = image
+        assert load_geojson_from_omero(conn, 1, "nonexistent") is None
+
+    def test_merge_geojson_accumulates_patches(self):
+        existing = self._make_geojson(patch={"x": 0, "y": 0, "width": 512, "height": 512})
+        new_patch = self._make_geojson(patch={"x": 512, "y": 0, "width": 512, "height": 512})
+        merged = merge_geojson_patches(existing, new_patch)
+        assert len(merged["features"]) == 2
+
+    def test_merge_geojson_replaces_same_patch(self):
+        existing = self._make_geojson(patch={"x": 0, "y": 0, "width": 512, "height": 512})
+        updated = self._make_geojson(patch={"x": 0, "y": 0, "width": 512, "height": 512})
+        updated["features"][0]["properties"]["featureType"] = "nucleus"
+        merged = merge_geojson_patches(existing, updated)
+        assert len(merged["features"]) == 1
+        assert merged["features"][0]["properties"]["featureType"] == "nucleus"
+
+    def test_merge_geojson_updates_channel_presentation(self):
+        existing = self._make_geojson()
+        new = self._make_geojson()
+        new["channel_presentation"][0]["contrast_end"] = 999
+        merged = merge_geojson_patches(existing, new)
+        assert merged["channel_presentation"][0]["contrast_end"] == 999

--- a/tests/test_omero_functions.py
+++ b/tests/test_omero_functions.py
@@ -418,6 +418,7 @@ class TestListUserTablesCreatedField:
         # Mock file annotation with a date
         mock_file_ann = Mock()
         mock_file_ann.getFile.return_value.getName.return_value = "my_table.h5"
+        mock_file_ann.getFile.return_value.getMimetype.return_value = "OMERO.tables"
         mock_file_ann.getDescription.return_value = ""
         mock_file_ann.getNs.return_value = "omero.tables"
         mock_date = Mock()
@@ -445,6 +446,7 @@ class TestListUserTablesCreatedField:
 
         mock_file_ann = Mock()
         mock_file_ann.getFile.return_value.getName.return_value = "my_table.h5"
+        mock_file_ann.getFile.return_value.getMimetype.return_value = "OMERO.tables"
         mock_file_ann.getDescription.return_value = ""
         mock_file_ann.getNs.return_value = "omero.tables"
         mock_file_ann.getDate.side_effect = AttributeError("no date")


### PR DESCRIPTION
## Summary

- Add `ChannelPresentation` and `FeatureType` pydantic models to `annotation_config.py`
- Add `to_json()` / `from_json()` serialization methods to `AnnotationConfig`
- Add OMERO persistence functions: `save_manifest_to_omero`, `load_manifest_from_omero`, `list_manifests_from_omero`, `delete_manifest_from_omero`
- Add GeoJSON persistence: `save_geojson_to_omero`, `load_geojson_from_omero`, `merge_geojson_patches`
- Add namespace helpers: `generate_set_id`, `manifest_namespace`, `geojson_namespace`

## Context

Part of the OMERO.biomero annotate app consolidation. These models and functions replace the dual YAML config + OMERO HDF5 table storage with a single JSON manifest per annotation set + per-image GeoJSON files.

## Test plan

- [x] 5 tests for ChannelPresentation/FeatureType models
- [x] 5 tests for JSON serialization round-trips
- [x] 6 tests for manifest persistence (load, list, not-found, namespace)
- [x] 5 tests for GeoJSON persistence (load, merge patches, replace same patch, channel presentation update)
- [x] Full suite: 245 passed, 5 skipped, 2 pre-existing failures (unrelated mock issue in TestListUserTablesCreatedField)

🤖 Generated with [Claude Code](https://claude.com/claude-code)