### PR TITLE
Feat extend sam annotation ch

### DIFF
--- a/annotations/annotation_config_default_annotation_workflow.yaml
+++ b/annotations/annotation_config_default_annotation_workflow.yaml
@@ -3,7 +3,7 @@ config_file_path: annotations/annotation_config_default_annotation_workflow.yaml
 name: default_annotation_workflow
 version: 1.0.0
 authors: []
-created: 2026-03-04 16:55:41.288849
+created: 2026-05-10 22:46:11.307107
 study:
   title: ''
   description: ''
@@ -37,6 +37,12 @@ spatial_coverage:
   z_range_end: null
   label_channel: null
   training_channels: null
+  context_channels: []
+  context_channel_names: null
+  context_channel_colormaps: null
+  normalization_method: percentile
+  percentile_low: 0.5
+  percentile_high: 99.5
   use_patches: false
   patch_size:
   - 512
@@ -77,6 +83,56 @@ omero:
   well_filter_mode: include
   table_id: 12345
 annotations:
+- image_id: 1
+  image_name: image_1
+  annotation_id: '1_0_0'
+  category: training
+  timepoint: 0
+  z_slice: 0
+  channel: 0
+  is_volumetric: false
+  z_start: 0
+  z_end: 0
+  z_length: 1
+  is_patch: false
+  patch_x: 0
+  patch_y: 0
+  patch_width: 0
+  patch_height: 0
+  processed: true
+  annotation_created_at: null
+  annotation_updated_at: null
+  annotation_type: segmentation_mask
+  roi_id: null
+  label_id: null
+  label_input_id: null
+  schema_attachment_id: null
+  channel_presentation: null
+- image_id: 3
+  image_name: image_3
+  annotation_id: '3_0_0'
+  category: training
+  timepoint: 0
+  z_slice: 0
+  channel: 0
+  is_volumetric: false
+  z_start: 0
+  z_end: 0
+  z_length: 1
+  is_patch: false
+  patch_x: 0
+  patch_y: 0
+  patch_width: 0
+  patch_height: 0
+  processed: false
+  annotation_created_at: null
+  annotation_updated_at: null
+  annotation_type: segmentation_mask
+  roi_id: null
+  label_id: null
+  label_input_id: null
+  schema_attachment_id: null
+  channel_presentation: null
 - image_id: 2
   image_name: image_2
   annotation_id: '2_0_0'
@@ -101,54 +157,8 @@ annotations:
   label_id: null
   label_input_id: null
   schema_attachment_id: null
-- image_id: 1
-  image_name: image_1
-  annotation_id: '1_0_0'
-  category: training
-  timepoint: 0
-  z_slice: 0
-  channel: 0
-  is_volumetric: false
-  z_start: 0
-  z_end: 0
-  z_length: 1
-  is_patch: false
-  patch_x: 0
-  patch_y: 0
-  patch_width: 0
-  patch_height: 0
-  processed: false
-  annotation_created_at: null
-  annotation_updated_at: null
-  annotation_type: segmentation_mask
-  roi_id: null
-  label_id: null
-  label_input_id: null
-  schema_attachment_id: null
-- image_id: 3
-  image_name: image_3
-  annotation_id: '3_0_0'
-  category: training
-  timepoint: 0
-  z_slice: 0
-  channel: 0
-  is_volumetric: false
-  z_start: 0
-  z_end: 0
-  z_length: 1
-  is_patch: false
-  patch_x: 0
-  patch_y: 0
-  patch_width: 0
-  patch_height: 0
-  processed: true
-  annotation_created_at: null
-  annotation_updated_at: null
-  annotation_type: segmentation_mask
-  roi_id: null
-  label_id: null
-  label_input_id: null
-  schema_attachment_id: null
+  channel_presentation: null
 documentation: null
 repository: null
 tags: []
+feature_types: []

--- a/src/omero_annotate_ai/core/annotation_config.py
+++ b/src/omero_annotate_ai/core/annotation_config.py
@@ -184,6 +184,9 @@ class AnnotationMethodology(BaseModel):
     )
 
 
+_CONTEXT_COLORMAP_CYCLE = ["blue", "magenta", "green", "yellow", "cyan"]
+
+
 class SpatialCoverage(BaseModel):
     """Spatial scope of annotations (MIFA requirement)"""
 
@@ -224,6 +227,25 @@ class SpatialCoverage(BaseModel):
         description="Channel index(es) used for model training input (e.g., brightfield). "
         "If not specified, defaults to [label_channel] for backward compatibility. "
         "Multiple channels supported if the training model permits.",
+    )
+
+    # Display-only context channels shown alongside the label channel during annotation.
+    # Never enter SAM embeddings, never saved as training pairs.
+    context_channels: List[int] = Field(
+        default_factory=list,
+        description="Display-only channel indices shown alongside the annotation channel in napari. "
+        "Never enter SAM embeddings or training data. OMERO channel index space.",
+    )
+    context_channel_names: Optional[List[str]] = Field(
+        default=None,
+        description="Display names for context_channels. "
+        "Length must match context_channels when provided. Defaults to 'ch{idx}'.",
+    )
+    context_channel_colormaps: Optional[List[str]] = Field(
+        default=None,
+        description="Napari colormap names for context_channels. "
+        "Length must match context_channels when provided. "
+        "Defaults to cycle ['blue', 'magenta', 'green', 'yellow', 'cyan'].",
     )
 
     # Image normalization settings (applied per-image, not per-patch)
@@ -300,6 +322,27 @@ class SpatialCoverage(BaseModel):
             return False
         return self.get_label_channel() not in self.get_training_channels()
 
+    def uses_context_channels(self) -> bool:
+        """Return True if any context channels are configured."""
+        return bool(self.context_channels)
+
+    def get_context_channel_specs(self) -> List[Tuple[int, str, str]]:
+        """Return [(channel_index, display_name, colormap), ...] for each context channel."""
+        specs = []
+        for i, ch_idx in enumerate(self.context_channels):
+            name = (
+                self.context_channel_names[i]
+                if self.context_channel_names is not None
+                else f"ch{ch_idx}"
+            )
+            cmap = (
+                self.context_channel_colormaps[i]
+                if self.context_channel_colormaps is not None
+                else _CONTEXT_COLORMAP_CYCLE[i % len(_CONTEXT_COLORMAP_CYCLE)]
+            )
+            specs.append((ch_idx, name, cmap))
+        return specs
+
     def get_z_range(self) -> Tuple[int, int]:
         """Get the z-range for volumetric processing"""
         if (
@@ -375,6 +418,29 @@ class SpatialCoverage(BaseModel):
                 if tc not in all_channels:
                     raise ValueError(
                         f"training_channels ({tc}) must be in channels list ({self.channels})"
+                    )
+
+        # Validate context_channels do not overlap with label_channel
+        if self.context_channels:
+            label_ch = self.get_label_channel()
+            overlapping = [ch for ch in self.context_channels if ch == label_ch]
+            if overlapping:
+                raise ValueError(
+                    f"context_channels {overlapping} overlap with label_channel ({label_ch}). "
+                    "Context channels must be different from the label channel."
+                )
+            # Validate optional list lengths match
+            if self.context_channel_names is not None:
+                if len(self.context_channel_names) != len(self.context_channels):
+                    raise ValueError(
+                        f"context_channel_names length ({len(self.context_channel_names)}) "
+                        f"must match context_channels length ({len(self.context_channels)})"
+                    )
+            if self.context_channel_colormaps is not None:
+                if len(self.context_channel_colormaps) != len(self.context_channels):
+                    raise ValueError(
+                        f"context_channel_colormaps length ({len(self.context_channel_colormaps)}) "
+                        f"must match context_channels length ({len(self.context_channels)})"
                     )
 
         return self

--- a/src/omero_annotate_ai/core/annotation_pipeline.py
+++ b/src/omero_annotate_ai/core/annotation_pipeline.py
@@ -694,8 +694,9 @@ class AnnotationPipeline:
 
         # Handle the initial image (already loaded before napari.run())
         initial_data = viewer.layers["image"].data
-        initial_idx = id_to_index.get(id(initial_data), 0)
-        update_context_layers(initial_idx)
+        initial_idx = id_to_index.get(id(initial_data))
+        if initial_idx is not None:
+            update_context_layers(initial_idx)
 
         # Subscribe for subsequent image transitions
         viewer.layers["image"].events.data.connect(on_image_data_changed)

--- a/src/omero_annotate_ai/core/annotation_pipeline.py
+++ b/src/omero_annotate_ai/core/annotation_pipeline.py
@@ -474,7 +474,7 @@ class AnnotationPipeline:
             images = []
             metadata = []
 
-            for image_obj, annotation_id, meta, row_idx in batch_data    :
+            for image_obj, annotation_id, meta, row_idx in batch_data:
                 # Load image data from OMERO
                 image_data = self._load_image_data(image_obj, meta)
                 images.append(image_data)
@@ -482,6 +482,9 @@ class AnnotationPipeline:
                 meta_with_image_id = meta.copy()
                 meta_with_image_id["image_id"] = image_obj.getId()
                 metadata.append((annotation_id, meta_with_image_id, row_idx))
+
+            # Build context images parallel list (empty dicts when no context channels)
+            context_images = self._build_context_images(batch_data)
 
             # Set up output paths
             output_path = Path(self.config.output.output_directory)
@@ -492,7 +495,7 @@ class AnnotationPipeline:
             # Run micro-SAM annotation
             model_type = self.config.ai_model.pretrained_from
 
-    
+
             # Run image series annotator with explicit napari.run() call
             viewer = image_series_annotator(
                 images=images,
@@ -504,6 +507,10 @@ class AnnotationPipeline:
                 is_volumetric=self.config.spatial_coverage.three_d,
                 skip_segmented=True,
             )
+
+            # Install context channel sidecar layers (no-op if none configured)
+            if self.config.spatial_coverage.uses_context_channels():
+                self._install_context_channel_hook(viewer, images, context_images)
 
             # Explicitly start the event loop - this will block until viewer is closed
             napari.run()

--- a/src/omero_annotate_ai/core/annotation_pipeline.py
+++ b/src/omero_annotate_ai/core/annotation_pipeline.py
@@ -495,7 +495,6 @@ class AnnotationPipeline:
             # Run micro-SAM annotation
             model_type = self.config.ai_model.pretrained_from
 
-
             # Run image series annotator with explicit napari.run() call
             viewer = image_series_annotator(
                 images=images,
@@ -509,8 +508,7 @@ class AnnotationPipeline:
             )
 
             # Install context channel sidecar layers (no-op if none configured)
-            if self.config.spatial_coverage.uses_context_channels():
-                self._install_context_channel_hook(viewer, images, context_images)
+            self._install_context_channel_hook(viewer, images, context_images)
 
             # Explicitly start the event loop - this will block until viewer is closed
             napari.run()

--- a/src/omero_annotate_ai/core/annotation_pipeline.py
+++ b/src/omero_annotate_ai/core/annotation_pipeline.py
@@ -605,6 +605,101 @@ class AnnotationPipeline:
 
         return image_data
 
+    def _build_context_images(self, batch_data: List[Tuple]) -> List[dict]:
+        """Build context_images parallel list for the context channel hook.
+
+        Returns a list of dicts, one per batch item. Each dict maps
+        channel display name -> numpy array. Empty dicts when no context
+        channels are configured.
+        """
+        if not self.config.spatial_coverage.uses_context_channels():
+            return [{} for _ in batch_data]
+
+        specs = self.config.spatial_coverage.get_context_channel_specs()
+        context_images = []
+        for image_obj, _annotation_id, meta, _row_idx in batch_data:
+            per_item = {}
+            for ch_idx, ch_name, _cmap in specs:
+                ctx_meta = {**meta, "channel_override": ch_idx}
+                arr = self._load_image_data(image_obj, ctx_meta)
+                per_item[ch_name] = arr
+            context_images.append(per_item)
+        return context_images
+
+    def _install_context_channel_hook(
+        self,
+        viewer,
+        images: List,
+        context_images: List[dict],
+    ) -> None:
+        """Install a napari events.data hook that keeps context layers in sync.
+
+        When image_series_annotator advances to the next image, updates each
+        context channel sidecar layer to match the new image index.
+        Does nothing when context_images contains only empty dicts.
+        """
+        specs = self.config.spatial_coverage.get_context_channel_specs()
+        if not specs:
+            return
+
+        # Build identity lookup: id(array) -> list index
+        id_to_index = {id(arr): i for i, arr in enumerate(images)}
+
+        def update_context_layers(idx: int) -> None:
+            per_item = context_images[idx]
+            for _ch_idx, ch_name, cmap in specs:
+                arr = per_item.get(ch_name)
+                if arr is None:
+                    continue
+                if ch_name in viewer.layers:
+                    try:
+                        viewer.layers[ch_name].data = arr
+                    except Exception:
+                        del viewer.layers[ch_name]
+                        viewer.add_image(
+                            arr,
+                            name=ch_name,
+                            colormap=cmap,
+                            blending="additive",
+                            visible=True,
+                        )
+                else:
+                    viewer.add_image(
+                        arr,
+                        name=ch_name,
+                        colormap=cmap,
+                        blending="additive",
+                        visible=True,
+                    )
+
+        def on_image_data_changed(event) -> None:
+            try:
+                new_data = viewer.layers["image"].data
+                idx = id_to_index.get(id(new_data))
+                if idx is None:
+                    # Fallback: scan with array identity then equality
+                    for i, arr in enumerate(images):
+                        if arr is new_data or (
+                            arr.shape == new_data.shape
+                            and arr.dtype == new_data.dtype
+                            and np.array_equal(arr, new_data)
+                        ):
+                            idx = i
+                            break
+                if idx is None:
+                    return
+                update_context_layers(idx)
+            except Exception:
+                pass  # Stale viewer reference during shutdown — ignore
+
+        # Handle the initial image (already loaded before napari.run())
+        initial_data = viewer.layers["image"].data
+        initial_idx = id_to_index.get(id(initial_data), 0)
+        update_context_layers(initial_idx)
+
+        # Subscribe for subsequent image transitions
+        viewer.layers["image"].events.data.connect(on_image_data_changed)
+
     def _process_annotation_results(
         self, annotation_results: dict
     ) -> None:

--- a/src/omero_annotate_ai/core/annotation_pipeline.py
+++ b/src/omero_annotate_ai/core/annotation_pipeline.py
@@ -610,6 +610,14 @@ class AnnotationPipeline:
 
         return image_data
 
+    def _load_and_stack_channels(self, image_obj, meta: dict, channel_indices: List[int]) -> np.ndarray:
+        """Load multiple channels and stack them channels-last: (Y,X,C) or (Z,Y,X,C)."""
+        arrays = [
+            self._load_image_data(image_obj, {**meta, "channel_override": ch})
+            for ch in channel_indices
+        ]
+        return np.stack(arrays, axis=-1)
+
     def _build_context_images(self, batch_data: List[Tuple]) -> List[dict]:
         """Build context_images parallel list for the context channel hook.
 
@@ -855,19 +863,21 @@ class AnnotationPipeline:
                     f"Could not save training channel image for {annotation_id}"
                 )
 
-    def _save_image_to_disk(self, image_data: np.ndarray, file_path: Path) -> bool:
+    def _save_image_to_disk(self, image_data: np.ndarray, file_path: Path, axes: Optional[str] = None) -> bool:
         """Save image data to disk using tifffile (preferred) or imageio fallback.
 
         Args:
             image_data: NumPy array of image data to save
             file_path: Path where the image should be saved
+            axes: Optional axes string for tifffile metadata (e.g. 'YXC', 'ZYXC')
 
         Returns:
             True if saved successfully, False otherwise
         """
         try:
             import tifffile
-            tifffile.imwrite(file_path, image_data)
+            kwargs = {"metadata": {"axes": axes}} if axes else {}
+            tifffile.imwrite(file_path, image_data, **kwargs)
             self._debug_print(f"Saved (tifffile): {file_path} - shape: {image_data.shape}, range: [{np.min(image_data)}-{np.max(image_data)}]")
             return True
         except ImportError:
@@ -1550,13 +1560,17 @@ class AnnotationPipeline:
             image_obj = self.conn.getObject("Image", img_id)
 
             if "label_input" in folders:
-                # Separate-channel: label channel → label_input/, training channel → training_input/
+                # Separate-channel: label channel → label_input/ (single-channel, annotation reference)
                 if self._save_training_image(image_obj, meta, annotation_id, folders["label_input"]) is None:
                     print(f"Warning: Could not save label channel image for {annotation_id}")
 
+                # training_input/ → all training channels stacked channels-last: (Y,X,C) or (Z,Y,X,C)
                 training_channels = self.config.spatial_coverage.get_training_channels()
-                train_meta = {**meta, "channel_override": training_channels[0]}
-                if self._save_training_image(image_obj, train_meta, annotation_id, folders["training_input"]) is None:
+                stacked = self._load_and_stack_channels(image_obj, meta, training_channels)
+                axes_str = "ZYXC" if stacked.ndim == 4 else "YXC"
+                train_file = folders["training_input"] / f"{annotation_id}.tif"
+                folders["training_input"].mkdir(parents=True, exist_ok=True)
+                if not self._save_image_to_disk(stacked, train_file, axes=axes_str):
                     print(f"Warning: Could not save training channel image for {annotation_id}")
             else:
                 # Single-channel: → input/

--- a/src/omero_annotate_ai/core/annotation_pipeline.py
+++ b/src/omero_annotate_ai/core/annotation_pipeline.py
@@ -668,6 +668,7 @@ class AnnotationPipeline:
                             blending="additive",
                             visible=True,
                         )
+                        viewer.layers.move(len(viewer.layers) - 1, 0)
                 else:
                     viewer.add_image(
                         arr,
@@ -676,6 +677,7 @@ class AnnotationPipeline:
                         blending="additive",
                         visible=True,
                     )
+                    viewer.layers.move(len(viewer.layers) - 1, 0)
 
         def on_image_data_changed(event) -> None:
             try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -369,6 +369,98 @@ class TestMultiChannelValidation:
 
 
 @pytest.mark.unit
+class TestContextChannelConfig:
+    """Tests for context_channels fields on SpatialCoverage."""
+
+    def test_defaults_empty(self):
+        from omero_annotate_ai.core.annotation_config import SpatialCoverage
+        sc = SpatialCoverage(channels=[0, 1, 2], timepoints=[0], z_slices=[0])
+        assert sc.context_channels == []
+        assert sc.context_channel_names is None
+        assert sc.context_channel_colormaps is None
+
+    def test_uses_context_channels_false_by_default(self):
+        from omero_annotate_ai.core.annotation_config import SpatialCoverage
+        sc = SpatialCoverage(channels=[0], timepoints=[0], z_slices=[0])
+        assert sc.uses_context_channels() is False
+
+    def test_uses_context_channels_true_when_set(self):
+        from omero_annotate_ai.core.annotation_config import SpatialCoverage
+        sc = SpatialCoverage(channels=[0, 1], timepoints=[0], z_slices=[0],
+                             context_channels=[1])
+        assert sc.uses_context_channels() is True
+
+    def test_get_context_channel_specs_defaults(self):
+        from omero_annotate_ai.core.annotation_config import SpatialCoverage
+        sc = SpatialCoverage(channels=[0, 1, 2], timepoints=[0], z_slices=[0],
+                             context_channels=[1, 2])
+        specs = sc.get_context_channel_specs()
+        assert len(specs) == 2
+        ch_idx0, name0, cmap0 = specs[0]
+        ch_idx1, name1, cmap1 = specs[1]
+        assert ch_idx0 == 1
+        assert ch_idx1 == 2
+        assert name0 == "ch1"
+        assert name1 == "ch2"
+        assert cmap0 in ["blue", "magenta", "green", "yellow", "cyan"]
+        assert cmap1 in ["blue", "magenta", "green", "yellow", "cyan"]
+
+    def test_get_context_channel_specs_custom_names(self):
+        from omero_annotate_ai.core.annotation_config import SpatialCoverage
+        sc = SpatialCoverage(channels=[0, 1], timepoints=[0], z_slices=[0],
+                             context_channels=[1],
+                             context_channel_names=["DAPI"])
+        specs = sc.get_context_channel_specs()
+        assert specs[0][1] == "DAPI"
+
+    def test_get_context_channel_specs_custom_colormaps(self):
+        from omero_annotate_ai.core.annotation_config import SpatialCoverage
+        sc = SpatialCoverage(channels=[0, 1], timepoints=[0], z_slices=[0],
+                             context_channels=[1],
+                             context_channel_colormaps=["magenta"])
+        specs = sc.get_context_channel_specs()
+        assert specs[0][2] == "magenta"
+
+    def test_validation_rejects_overlap_with_label_channel(self):
+        from omero_annotate_ai.core.annotation_config import SpatialCoverage
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError, match="context_channels"):
+            SpatialCoverage(channels=[0, 1], timepoints=[0], z_slices=[0],
+                            label_channel=0, context_channels=[0])
+
+    def test_validation_rejects_mismatched_names_length(self):
+        from omero_annotate_ai.core.annotation_config import SpatialCoverage
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            SpatialCoverage(channels=[0, 1, 2], timepoints=[0], z_slices=[0],
+                            context_channels=[1, 2],
+                            context_channel_names=["DAPI"])  # length 1, should be 2
+
+    def test_validation_rejects_mismatched_colormaps_length(self):
+        from omero_annotate_ai.core.annotation_config import SpatialCoverage
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            SpatialCoverage(channels=[0, 1, 2], timepoints=[0], z_slices=[0],
+                            context_channels=[1, 2],
+                            context_channel_colormaps=["blue"])  # length 1, should be 2
+
+    def test_yaml_round_trip(self):
+        from omero_annotate_ai.core.annotation_config import AnnotationConfig
+        config = AnnotationConfig(name="test")
+        config.spatial_coverage.channels = [0, 1]
+        config.spatial_coverage.context_channels = [1]
+        config.spatial_coverage.context_channel_names = ["DAPI"]
+        config.spatial_coverage.context_channel_colormaps = ["blue"]
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            config.save_yaml(f.name)
+            loaded = AnnotationConfig.from_yaml(f.name)
+        Path(f.name).unlink()
+        assert loaded.spatial_coverage.context_channels == [1]
+        assert loaded.spatial_coverage.context_channel_names == ["DAPI"]
+        assert loaded.spatial_coverage.context_channel_colormaps == ["blue"]
+
+
+@pytest.mark.unit
 class TestMultiChannelYamlSerialization:
     """Test YAML serialization with channel fields."""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -378,6 +378,7 @@ class TestContextChannelConfig:
         assert sc.context_channels == []
         assert sc.context_channel_names is None
         assert sc.context_channel_colormaps is None
+        assert sc.get_context_channel_specs() == []
 
     def test_uses_context_channels_false_by_default(self):
         from omero_annotate_ai.core.annotation_config import SpatialCoverage
@@ -402,8 +403,8 @@ class TestContextChannelConfig:
         assert ch_idx1 == 2
         assert name0 == "ch1"
         assert name1 == "ch2"
-        assert cmap0 in ["blue", "magenta", "green", "yellow", "cyan"]
-        assert cmap1 in ["blue", "magenta", "green", "yellow", "cyan"]
+        assert cmap0 == "blue"
+        assert cmap1 == "magenta"
 
     def test_get_context_channel_specs_custom_names(self):
         from omero_annotate_ai.core.annotation_config import SpatialCoverage

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import patch, Mock, MagicMock
 import tempfile
 from pathlib import Path
+import numpy as np
 
 from omero_annotate_ai.core.annotation_pipeline import AnnotationPipeline
 from omero_annotate_ai.core.annotation_config import create_default_config
@@ -1122,3 +1123,126 @@ class TestContextChannelHook:
 
         # DAPI layer data should have been updated to dapi_arr1
         assert mock_dapi_layer.data is dapi_arr1
+
+
+@pytest.mark.unit
+class TestCellposeMultiChannelSaving:
+    """Test that _save_images_for_cellpose saves channels-last multi-channel TIFFs."""
+
+    def _make_pipeline(self, training_channels, label_channel=0):
+        from omero_annotate_ai.core.annotation_config import create_default_config
+        config = create_default_config()
+        config.spatial_coverage.channels = list(
+            set([label_channel] + training_channels)
+        )
+        config.spatial_coverage.label_channel = label_channel
+        config.spatial_coverage.training_channels = training_channels
+        pipeline = AnnotationPipeline(config, conn=Mock())
+        return pipeline
+
+    def test_single_channel_saves_as_YXC(self, tmp_path):
+        """Single training channel is saved as (Y, X, 1) channels-last."""
+        pipeline = self._make_pipeline(training_channels=[0])
+        pipeline.config.output.output_directory = str(tmp_path)
+
+        h, w = 32, 32
+        ch0 = np.zeros((h, w), dtype=np.uint16) + 10
+
+        mock_image = Mock()
+        pipeline._load_image_data = Mock(return_value=ch0)
+
+        stacked = pipeline._load_and_stack_channels(mock_image, {"timepoint": 0, "z_slice": 0}, [0])
+        assert stacked.shape == (h, w, 1)
+        np.testing.assert_array_equal(stacked[..., 0], ch0)
+
+    def test_multi_channel_saves_as_YXC(self, tmp_path):
+        """Two training channels are stacked as (Y, X, 2)."""
+        pipeline = self._make_pipeline(training_channels=[0, 1])
+        pipeline.config.output.output_directory = str(tmp_path)
+
+        h, w = 32, 32
+        ch0 = np.zeros((h, w), dtype=np.uint16) + 10
+        ch1 = np.zeros((h, w), dtype=np.uint16) + 20
+
+        def load_side_effect(image_obj, meta):
+            ch = meta.get("channel_override", 0)
+            return ch0 if ch == 0 else ch1
+
+        mock_image = Mock()
+        pipeline._load_image_data = Mock(side_effect=load_side_effect)
+
+        stacked = pipeline._load_and_stack_channels(mock_image, {"timepoint": 0, "z_slice": 0}, [0, 1])
+        assert stacked.shape == (h, w, 2)
+        np.testing.assert_array_equal(stacked[..., 0], ch0)
+        np.testing.assert_array_equal(stacked[..., 1], ch1)
+
+    def test_3d_multi_channel_saves_as_ZYXC(self, tmp_path):
+        """3D images with two channels are stacked as (Z, Y, X, 2)."""
+        pipeline = self._make_pipeline(training_channels=[0, 1])
+
+        z, h, w = 5, 32, 32
+        ch0 = np.zeros((z, h, w), dtype=np.uint16) + 10
+        ch1 = np.zeros((z, h, w), dtype=np.uint16) + 20
+
+        def load_side_effect(image_obj, meta):
+            ch = meta.get("channel_override", 0)
+            return ch0 if ch == 0 else ch1
+
+        mock_image = Mock()
+        pipeline._load_image_data = Mock(side_effect=load_side_effect)
+
+        stacked = pipeline._load_and_stack_channels(mock_image, {"timepoint": 0, "is_volumetric": True}, [0, 1])
+        assert stacked.shape == (z, h, w, 2)
+
+    def test_all_training_channels_in_output(self, tmp_path):
+        """All channels in training_channels appear in the stacked output — none silently dropped."""
+        pipeline = self._make_pipeline(training_channels=[0, 1, 2])
+
+        h, w = 16, 16
+        arrays = {i: np.full((h, w), i * 10, dtype=np.uint16) for i in range(3)}
+
+        def load_side_effect(image_obj, meta):
+            return arrays[meta.get("channel_override", 0)]
+
+        mock_image = Mock()
+        pipeline._load_image_data = Mock(side_effect=load_side_effect)
+
+        stacked = pipeline._load_and_stack_channels(mock_image, {"timepoint": 0, "z_slice": 0}, [0, 1, 2])
+        assert stacked.shape == (h, w, 3)
+        for i in range(3):
+            np.testing.assert_array_equal(stacked[..., i], arrays[i])
+
+    def test_label_input_stays_single_channel(self, tmp_path):
+        """label_input/ TIFF is still saved as (Y, X) — not stacked."""
+        pipeline = self._make_pipeline(training_channels=[1], label_channel=0)
+        pipeline.config.output.output_directory = str(tmp_path)
+
+        h, w = 16, 16
+        label_arr = np.zeros((h, w), dtype=np.uint16) + 5
+        train_arr = np.zeros((h, w), dtype=np.uint16) + 9
+
+        def load_side_effect(image_obj, meta):
+            ch = meta.get("channel_override", 0)
+            return label_arr if ch == 0 else train_arr
+
+        mock_conn = Mock()
+        mock_image = Mock()
+        mock_conn.getObject = Mock(return_value=mock_image)
+        pipeline.conn = mock_conn
+        pipeline._load_image_data = Mock(side_effect=load_side_effect)
+
+        meta = {"timepoint": 0, "z_slice": 0, "channel_override": 0}
+        processing_units = [(1, "img_001", meta, 0)]
+        pipeline._save_images_for_cellpose(processing_units)
+
+        import tifffile
+        label_file = tmp_path / "label_input" / "img_001.tif"
+        assert label_file.exists()
+        saved = tifffile.imread(str(label_file))
+        assert saved.ndim == 2, f"label_input should be 2D, got shape {saved.shape}"
+
+        train_file = tmp_path / "training_input" / "img_001.tif"
+        assert train_file.exists()
+        saved_train = tifffile.imread(str(train_file))
+        assert saved_train.ndim == 3, f"training_input should be 3D (Y,X,C), got shape {saved_train.shape}"
+        assert saved_train.shape == (h, w, 1)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,7 +1,7 @@
 """Tests for the annotation pipeline."""
 
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import patch, Mock, MagicMock
 import tempfile
 from pathlib import Path
 
@@ -934,3 +934,191 @@ class TestAnnotationTimestamps:
         # IDs should remain None when not provided
         assert annotation.roi_id is None
         assert annotation.label_id is None
+
+
+@pytest.mark.unit
+class TestContextChannelHook:
+    """Tests for context channel hook in _run_micro_sam_annotation."""
+
+    @patch('omero_annotate_ai.core.annotation_pipeline.get_dask_image_single')
+    def test_build_context_images_empty_when_no_context_channels(self, mock_dask):
+        """With no context_channels, context_images should be list of empty dicts."""
+        import numpy as np
+        from omero_annotate_ai.core.annotation_config import create_default_config
+        from omero_annotate_ai.core.annotation_pipeline import AnnotationPipeline
+
+        label_arr = np.zeros((64, 64), dtype=np.uint16)
+        mock_dask.return_value = label_arr
+
+        config = create_default_config()
+        config.spatial_coverage.channels = [0]
+        # No context_channels set
+        pipeline = AnnotationPipeline(config, conn=Mock())
+
+        mock_image = Mock()
+        mock_image.getId.return_value = 1
+        mock_image.getSizeX.return_value = 64
+        mock_image.getSizeY.return_value = 64
+        mock_image.getSizeC.return_value = 1
+        mock_image.getSizeZ.return_value = 1
+        mock_image.getSizeT.return_value = 1
+
+        meta = {"timepoint": 0, "z_slice": 0, "is_volumetric": False}
+        batch_data = [(mock_image, "ann1", meta, 0)]
+
+        context_images = pipeline._build_context_images(batch_data)
+        assert context_images == [{}]
+
+    @patch('omero_annotate_ai.core.annotation_pipeline.get_dask_image_single')
+    def test_build_context_images_loads_correct_channel(self, mock_dask):
+        """With context_channels=[1], loads channel 1 for each batch item."""
+        import numpy as np
+        from omero_annotate_ai.core.annotation_config import create_default_config
+        from omero_annotate_ai.core.annotation_pipeline import AnnotationPipeline
+
+        label_arr = np.zeros((64, 64), dtype=np.uint16)
+        ctx_arr = np.ones((64, 64), dtype=np.uint16) * 100
+        # Return label_arr for channel 0, ctx_arr for channel 1
+        def side_effect(**kwargs):
+            if kwargs.get("channels") == [1]:
+                return ctx_arr
+            return label_arr
+        mock_dask.side_effect = side_effect
+
+        config = create_default_config()
+        config.spatial_coverage.channels = [0, 1]
+        config.spatial_coverage.context_channels = [1]
+        config.spatial_coverage.context_channel_names = ["DAPI"]
+        pipeline = AnnotationPipeline(config, conn=Mock())
+
+        mock_image = Mock()
+        mock_image.getId.return_value = 1
+        mock_image.getSizeX.return_value = 64
+        mock_image.getSizeY.return_value = 64
+        mock_image.getSizeC.return_value = 2
+        mock_image.getSizeZ.return_value = 1
+        mock_image.getSizeT.return_value = 1
+
+        meta = {"timepoint": 0, "z_slice": 0, "is_volumetric": False}
+        batch_data = [(mock_image, "ann1", meta, 0)]
+
+        context_images = pipeline._build_context_images(batch_data)
+        assert len(context_images) == 1
+        assert "DAPI" in context_images[0]
+        np.testing.assert_array_equal(context_images[0]["DAPI"], ctx_arr)
+
+    def test_install_context_channel_hook_no_op_when_empty(self):
+        """Hook install is a no-op when context_images contains empty dicts."""
+        import numpy as np
+        from omero_annotate_ai.core.annotation_config import create_default_config
+        from omero_annotate_ai.core.annotation_pipeline import AnnotationPipeline
+
+        config = create_default_config()
+        pipeline = AnnotationPipeline(config, conn=Mock())
+
+        mock_viewer = Mock()
+        images = [np.zeros((64, 64))]
+        context_images = [{}]
+
+        # Should not raise; viewer.layers should not be touched
+        pipeline._install_context_channel_hook(mock_viewer, images, context_images)
+        mock_viewer.layers.assert_not_called()
+
+    def test_install_context_channel_hook_adds_initial_layer(self):
+        """Hook install should add a context layer for the initial image."""
+        import numpy as np
+        from omero_annotate_ai.core.annotation_config import create_default_config
+        from omero_annotate_ai.core.annotation_pipeline import AnnotationPipeline
+
+        config = create_default_config()
+        config.spatial_coverage.channels = [0, 1]
+        config.spatial_coverage.context_channels = [1]
+        config.spatial_coverage.context_channel_names = ["DAPI"]
+        config.spatial_coverage.context_channel_colormaps = ["blue"]
+        pipeline = AnnotationPipeline(config, conn=Mock())
+
+        label_arr = np.zeros((64, 64), dtype=np.uint16)
+        dapi_arr = np.ones((64, 64), dtype=np.uint16) * 50
+
+        # Mock viewer: layers["image"].data returns label_arr
+        mock_image_layer = Mock()
+        mock_image_layer.data = label_arr
+
+        mock_layers = MagicMock()
+        mock_layers.__getitem__ = Mock(return_value=mock_image_layer)
+        mock_layers.__contains__ = Mock(return_value=False)  # "DAPI" not in layers
+
+        mock_viewer = Mock()
+        mock_viewer.layers = mock_layers
+
+        images = [label_arr]
+        context_images = [{"DAPI": dapi_arr}]
+
+        pipeline._install_context_channel_hook(mock_viewer, images, context_images)
+
+        # Verify add_image was called with DAPI array and correct kwargs
+        mock_viewer.add_image.assert_called_once_with(
+            dapi_arr, name="DAPI", colormap="blue", blending="additive", visible=True
+        )
+
+    def test_context_hook_callback_updates_layer_on_next_image(self):
+        """Simulating next-image event: callback should update DAPI layer data."""
+        import numpy as np
+        from omero_annotate_ai.core.annotation_config import create_default_config
+        from omero_annotate_ai.core.annotation_pipeline import AnnotationPipeline
+
+        config = create_default_config()
+        config.spatial_coverage.channels = [0, 1]
+        config.spatial_coverage.context_channels = [1]
+        config.spatial_coverage.context_channel_names = ["DAPI"]
+        config.spatial_coverage.context_channel_colormaps = ["blue"]
+        pipeline = AnnotationPipeline(config, conn=Mock())
+
+        label_arr0 = np.zeros((64, 64), dtype=np.uint16)
+        label_arr1 = np.ones((64, 64), dtype=np.uint16)
+        dapi_arr0 = np.zeros((64, 64), dtype=np.uint16) + 10
+        dapi_arr1 = np.zeros((64, 64), dtype=np.uint16) + 20
+
+        images = [label_arr0, label_arr1]
+        context_images = [{"DAPI": dapi_arr0}, {"DAPI": dapi_arr1}]
+
+        # Simulate viewer: image layer starts at label_arr0, transitions to label_arr1
+        mock_dapi_layer = Mock()
+        mock_image_layer = Mock()
+        mock_image_layer.data = label_arr0  # initial state
+
+        event_callbacks = []
+
+        class MockEvents:
+            def connect(self, cb):
+                event_callbacks.append(cb)
+
+        mock_image_layer.events = Mock()
+        mock_image_layer.events.data = MockEvents()
+
+        def layers_getitem(name):
+            if name == "image":
+                return mock_image_layer
+            if name == "DAPI":
+                return mock_dapi_layer
+            raise KeyError(name)
+
+        def layers_contains(name):
+            return name == "DAPI"  # After first call, DAPI layer exists
+
+        mock_layers = MagicMock()
+        mock_layers.__getitem__ = Mock(side_effect=layers_getitem)
+        mock_layers.__contains__ = Mock(side_effect=layers_contains)
+
+        mock_viewer = Mock()
+        mock_viewer.layers = mock_layers
+
+        pipeline._install_context_channel_hook(mock_viewer, images, context_images)
+
+        # Simulate napari firing events.data when image advances to label_arr1
+        mock_image_layer.data = label_arr1
+        assert len(event_callbacks) == 1
+        event_callbacks[0](Mock())  # fire the callback
+
+        # DAPI layer data should have been updated to dapi_arr1
+        assert mock_dapi_layer.data is dapi_arr1

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1022,7 +1022,7 @@ class TestContextChannelHook:
 
         # Should not raise; viewer.layers should not be touched
         pipeline._install_context_channel_hook(mock_viewer, images, context_images)
-        mock_viewer.layers.assert_not_called()
+        mock_viewer.add_image.assert_not_called()
 
     def test_install_context_channel_hook_adds_initial_layer(self):
         """Hook install should add a context layer for the initial image."""


### PR DESCRIPTION
This pull request introduces support for context channels in the annotation workflow, allowing users to display additional image channels as visual references during annotation (without using them for training or embedding). The changes include updates to the configuration schema, core logic, and tests to handle context channels, their display names, and colormaps, as well as validation to ensure correct usage.

**Context channel support:**

* Added `context_channels`, `context_channel_names`, and `context_channel_colormaps` fields to the `SpatialCoverage` model in `annotation_config.py`, with logic for default colormaps and display names, and validation to prevent overlap with the label channel and ensure matching list lengths. [[1]](diffhunk://#diff-5c141582436482285ec1058913af9e86cbd127960a3a605b2664e795f3b97064R232-R250) [[2]](diffhunk://#diff-5c141582436482285ec1058913af9e86cbd127960a3a605b2664e795f3b97064R325-R345) [[3]](diffhunk://#diff-5c141582436482285ec1058913af9e86cbd127960a3a605b2664e795f3b97064R423-R445)
* Updated the annotation workflow to build and synchronize context channel images in the napari viewer, including hooks to update these layers as the user navigates through images. [[1]](diffhunk://#diff-2ffb583ad9a6a47f5b8f24adadaed3a1c5027cc9ee8b12c9c8eb79269d6bbb5bR486-R488) [[2]](diffhunk://#diff-2ffb583ad9a6a47f5b8f24adadaed3a1c5027cc9ee8b12c9c8eb79269d6bbb5bR510-R512) [[3]](diffhunk://#diff-2ffb583ad9a6a47f5b8f24adadaed3a1c5027cc9ee8b12c9c8eb79269d6bbb5bR613-R710)

**Configuration and YAML schema:**

* Extended the default annotation workflow YAML to include context channel fields and normalization settings.
* Updated annotation entries in the YAML to reflect new structure and fields. [[1]](diffhunk://#diff-df096d250d30e17de4261245e1a3e71a5cac9825693deb588659d8cfb70ec4dbL80-R88) [[2]](diffhunk://#diff-df096d250d30e17de4261245e1a3e71a5cac9825693deb588659d8cfb70ec4dbL104-R113) [[3]](diffhunk://#diff-df096d250d30e17de4261245e1a3e71a5cac9825693deb588659d8cfb70ec4dbL128-R138) [[4]](diffhunk://#diff-df096d250d30e17de4261245e1a3e71a5cac9825693deb588659d8cfb70ec4dbR160-R164)
* Updated the creation timestamp in the YAML config.

**Testing:**

* Added comprehensive unit tests for the new context channel fields, including validation, default behaviors, and YAML round-tripping in `test_config.py`.
* Minor update to test imports for consistency.