### PR TITLE
feat: enforce training split coherence and sync fractions (v0.3.0)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -20356,7 +20356,7 @@ packages:
 - pypi: ./
   name: omero-annotate-ai
   version: 0.3.0
-  sha256: 27e7a633368253e008b6a81053b4c9515e12a1b76dae1ae6eef4e055319bd158
+  sha256: 339a8b917f6ed21b4830aea5fcd5525e631e2e3645184904326df034f3190082
   requires_dist:
   - numpy>=1.21.0,<2.0
   - pandas>=1.3.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -20355,7 +20355,7 @@ packages:
   timestamp: 1743700382939
 - pypi: ./
   name: omero-annotate-ai
-  version: 0.2.9
+  version: 0.3.0
   sha256: 27e7a633368253e008b6a81053b4c9515e12a1b76dae1ae6eef4e055319bd158
   requires_dist:
   - numpy>=1.21.0,<2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omero-annotate-ai"
-version = "0.2.9"
+version = "0.3.0"
 description = "OMERO integration for AI-powered image annotation and segmentation workflows"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/omero_annotate_ai/core/annotation_config.py
+++ b/src/omero_annotate_ai/core/annotation_config.py
@@ -1,6 +1,7 @@
 """Configuration management for OMERO AI annotation workflows."""
 
 import json
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -563,10 +564,28 @@ class TrainingConfig(BaseModel):
                     f"train + validation + test fractions must sum to <= 1.0 (got {total:.2f})"
                 )
             # Note: train_fraction=0 is allowed (inference-only workflows)
+            if self.train_n != 3 or self.validate_n != 2 or self.test_n != 0:
+                warnings.warn(
+                    "train_n/validate_n/test_n are set but ignored because segment_all=True. "
+                    "Use train_fraction/validation_fraction/test_fraction instead.",
+                    UserWarning,
+                    stacklevel=2,
+                )
         else:
             # Count-based mode: validate counts
             if self.train_n < 1:
                 raise ValueError("train_n must be at least 1 when segment_all=False")
+            if (
+                self.train_fraction != 0.7
+                or self.validation_fraction != 0.3
+                or self.test_fraction != 0.0
+            ):
+                warnings.warn(
+                    "train_fraction/validation_fraction/test_fraction are set but ignored "
+                    "because segment_all=False. Use train_n/validate_n/test_n instead.",
+                    UserWarning,
+                    stacklevel=2,
+                )
         return self
 
 

--- a/src/omero_annotate_ai/core/annotation_pipeline.py
+++ b/src/omero_annotate_ai/core/annotation_pipeline.py
@@ -266,9 +266,16 @@ class AnnotationPipeline:
             )
         else:
             # Select subset with specific counts
-            n_train = min(self.config.training.train_n, n_total)
-            n_val = min(self.config.training.validate_n, n_total - n_train)
-            n_test = min(self.config.training.test_n, n_total - n_train - n_val)
+            n_train = self.config.training.train_n
+            n_val = self.config.training.validate_n
+            n_test = self.config.training.test_n
+            n_requested = n_train + n_val + n_test
+            if n_requested > n_total:
+                raise ValueError(
+                    f"Not enough images: requested {n_train} training + {n_val} validation"
+                    f" + {n_test} test = {n_requested}, but only {n_total} images available."
+                    f" Reduce train_n, validate_n, or test_n in the annotation settings."
+                )
 
             # Randomly select images
             shuffled_indices = list(range(n_total))
@@ -284,6 +291,12 @@ class AnnotationPipeline:
                 ["validation"] * n_val +
                 ["test"] * n_test
             )
+
+            # Sync fractions to reflect the actual count-mode split
+            if n_total > 0:
+                self.config.training.train_fraction = round(n_train / n_total, 4)
+                self.config.training.validation_fraction = round(n_val / n_total, 4)
+                self.config.training.test_fraction = round(n_test / n_total, 4)
 
         # Create ImageAnnotation objects for each processing unit
         for image, category in zip(selected_images, image_categories):
@@ -1273,11 +1286,19 @@ class AnnotationPipeline:
             if self.config.training.segment_all:
                 selected_indices = list(range(n_total))
             else:
-                n_train = min(self.config.training.train_n, n_total)
-                n_val = min(self.config.training.validate_n, n_total - n_train)
+                n_train = self.config.training.train_n
+                n_val = self.config.training.validate_n
+                n_test = self.config.training.test_n
+                n_requested = n_train + n_val + n_test
+                if n_requested > n_total:
+                    raise ValueError(
+                        f"Not enough images: requested {n_train} training + {n_val} validation"
+                        f" + {n_test} test = {n_requested}, but only {n_total} images available."
+                        f" Reduce train_n, validate_n, or test_n in the annotation settings."
+                    )
                 shuffled_indices = list(range(n_total))
                 random.shuffle(shuffled_indices)
-                selected_indices = shuffled_indices[: n_train + n_val]
+                selected_indices = shuffled_indices[: n_requested]
 
             selected_image_ids = [image_ids[i] for i in selected_indices]
             images_list = self.get_images_by_ids(selected_image_ids)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -958,3 +958,42 @@ class TestAnnotationConfigJSON:
         json_str = config.to_json()
         loaded = type(config).from_json(json_str)
         assert config.to_dict() == loaded.to_dict()
+
+
+@pytest.mark.unit
+class TestTrainingConfigWarnings:
+    """Test that TrainingConfig warns when the inactive split set has non-default values."""
+
+    def test_warns_when_fractions_set_but_count_mode(self):
+        from omero_annotate_ai.core.annotation_config import TrainingConfig
+        with pytest.warns(UserWarning, match="train_fraction.*ignored.*segment_all=False"):
+            TrainingConfig(segment_all=False, train_n=3, validate_n=2, test_n=0, train_fraction=0.5)
+
+    def test_warns_when_validation_fraction_set_but_count_mode(self):
+        from omero_annotate_ai.core.annotation_config import TrainingConfig
+        with pytest.warns(UserWarning, match="ignored.*segment_all=False"):
+            TrainingConfig(segment_all=False, train_n=3, validate_n=2, test_n=0, validation_fraction=0.1)
+
+    def test_warns_when_counts_set_but_fraction_mode(self):
+        from omero_annotate_ai.core.annotation_config import TrainingConfig
+        with pytest.warns(UserWarning, match="train_n.*ignored.*segment_all=True"):
+            TrainingConfig(segment_all=True, train_n=10, validate_n=2, test_n=0)
+
+    def test_no_warning_when_only_active_count_set_changed(self):
+        from omero_annotate_ai.core.annotation_config import TrainingConfig
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            TrainingConfig(segment_all=False, train_n=5, validate_n=2, test_n=0)
+
+    def test_no_warning_when_only_active_fraction_set_changed(self):
+        from omero_annotate_ai.core.annotation_config import TrainingConfig
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            TrainingConfig(
+                segment_all=True,
+                train_fraction=0.6,
+                validation_fraction=0.4,
+                test_fraction=0.0,
+            )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -194,6 +194,10 @@ class TestAnnotationPipeline:
         assert title == unique_name
 
         # Test 4: Verify create_or_replace_tracking_table receives the exact config name
+        config.training.train_n = 1
+        config.training.validate_n = 1
+        config.training.test_n = 0
+        config.training.segment_all = False
         mock_images = []
         for i in range(2):
             mock_img = Mock()
@@ -612,6 +616,121 @@ class TestAnnotationPipeline:
                 validation_fraction=0.3,
                 test_fraction=0.3,  # Total = 1.2 > 1.0
             )
+
+
+@pytest.mark.unit
+class TestImageCountValidation:
+    """Test that count-mode split raises an error when images are insufficient."""
+
+    def _make_images(self, n):
+        images = []
+        for i in range(n):
+            img = Mock()
+            img.getId.return_value = i + 1
+            img.getName.return_value = f"img{i + 1}"
+            img.getSizeT.return_value = 1
+            img.getSizeZ.return_value = 1
+            images.append(img)
+        return images
+
+    def _pipeline(self, train_n, validate_n, test_n):
+        config = create_default_config()
+        config.training.segment_all = False
+        config.training.train_n = train_n
+        config.training.validate_n = validate_n
+        config.training.test_n = test_n
+        return AnnotationPipeline(config, conn=Mock())
+
+    def test_exact_count_succeeds(self):
+        pipeline = self._pipeline(train_n=3, validate_n=2, test_n=0)
+        pipeline._prepare_processing_units(self._make_images(5))
+        categories = [a.category for a in pipeline.config.annotations]
+        assert len(categories) == 5
+        assert categories.count("training") == 3
+        assert categories.count("validation") == 2
+
+    def test_surplus_images_succeeds(self):
+        pipeline = self._pipeline(train_n=3, validate_n=2, test_n=1)
+        pipeline._prepare_processing_units(self._make_images(10))
+        categories = [a.category for a in pipeline.config.annotations]
+        assert len(categories) == 6
+        assert categories.count("training") == 3
+        assert categories.count("validation") == 2
+        assert categories.count("test") == 1
+
+    def test_insufficient_raises_error(self):
+        pipeline = self._pipeline(train_n=3, validate_n=2, test_n=0)
+        with pytest.raises(ValueError, match="Not enough images"):
+            pipeline._prepare_processing_units(self._make_images(4))
+
+    def test_train_only_no_val_succeeds(self):
+        pipeline = self._pipeline(train_n=3, validate_n=0, test_n=0)
+        pipeline._prepare_processing_units(self._make_images(3))
+        categories = [a.category for a in pipeline.config.annotations]
+        assert len(categories) == 3
+        assert all(c == "training" for c in categories)
+
+    def test_one_image_short_raises_error(self):
+        pipeline = self._pipeline(train_n=3, validate_n=2, test_n=1)
+        with pytest.raises(ValueError, match="Not enough images"):
+            pipeline._prepare_processing_units(self._make_images(5))
+
+    def test_error_message_content(self):
+        pipeline = self._pipeline(train_n=2, validate_n=2, test_n=0)
+        with pytest.raises(ValueError) as exc_info:
+            pipeline._prepare_processing_units(self._make_images(2))
+        msg = str(exc_info.value)
+        assert "2 training" in msg
+        assert "2 validation" in msg
+        assert "4" in msg
+        assert "2 images available" in msg
+
+
+@pytest.mark.unit
+class TestFractionSync:
+    """Test that count-mode runs sync train_fraction/validation_fraction after the split."""
+
+    def _make_images(self, n):
+        images = []
+        for i in range(n):
+            img = Mock()
+            img.getId.return_value = i + 1
+            img.getName.return_value = f"img{i + 1}"
+            img.getSizeT.return_value = 1
+            img.getSizeZ.return_value = 1
+            images.append(img)
+        return images
+
+    def _pipeline(self, train_n, validate_n, test_n):
+        config = create_default_config()
+        config.training.segment_all = False
+        config.training.train_n = train_n
+        config.training.validate_n = validate_n
+        config.training.test_n = test_n
+        return AnnotationPipeline(config, conn=Mock())
+
+    def test_count_mode_syncs_fractions(self):
+        pipeline = self._pipeline(train_n=3, validate_n=2, test_n=0)
+        pipeline._prepare_processing_units(self._make_images(10))
+        assert pipeline.config.training.train_fraction == pytest.approx(0.3)
+        assert pipeline.config.training.validation_fraction == pytest.approx(0.2)
+        assert pipeline.config.training.test_fraction == pytest.approx(0.0)
+
+    def test_count_mode_fractions_sum_to_one_or_less(self):
+        pipeline = self._pipeline(train_n=3, validate_n=2, test_n=1)
+        pipeline._prepare_processing_units(self._make_images(10))
+        total = (
+            pipeline.config.training.train_fraction
+            + pipeline.config.training.validation_fraction
+            + pipeline.config.training.test_fraction
+        )
+        assert total <= 1.0
+
+    def test_count_mode_no_val_fraction_is_zero(self):
+        pipeline = self._pipeline(train_n=5, validate_n=0, test_n=0)
+        pipeline._prepare_processing_units(self._make_images(10))
+        assert pipeline.config.training.validation_fraction == pytest.approx(0.0)
+        assert pipeline.config.training.test_fraction == pytest.approx(0.0)
 
 
 @pytest.mark.unit

--- a/tests/test_training_config_validation.py
+++ b/tests/test_training_config_validation.py
@@ -45,12 +45,14 @@ class TestFractionModeValidation:
     def test_train_n_zero_allowed_in_fraction_mode(self):
         """train_n=0 should NOT raise error when segment_all=True."""
         # This would fail with old validation that always required train_n >= 1
-        config = TrainingConfig(
-            segment_all=True,
-            train_n=0,
-            validate_n=0,
-            test_n=0,
-        )
+        # A warning is expected because train_n/validate_n differ from their defaults
+        with pytest.warns(UserWarning, match="train_n.*ignored.*segment_all=True"):
+            config = TrainingConfig(
+                segment_all=True,
+                train_n=0,
+                validate_n=0,
+                test_n=0,
+            )
         assert config.train_n == 0
 
     def test_fractions_exactly_one_allowed(self):
@@ -119,16 +121,17 @@ class TestCountModeValidation:
         """Invalid fractions should NOT raise error when segment_all=False.
 
         In count mode, fractions are ignored, so even invalid fractions
-        should not cause validation errors.
+        should not cause validation errors. A warning is expected because
+        non-default fractions are set while in count mode.
         """
-        # This would fail if fraction validation ran in count mode
-        config = TrainingConfig(
-            segment_all=False,
-            train_n=3,
-            train_fraction=0.9,
-            validation_fraction=0.9,
-            test_fraction=0.9,  # Total = 2.7, but should be ignored
-        )
+        with pytest.warns(UserWarning, match="train_fraction.*ignored.*segment_all=False"):
+            config = TrainingConfig(
+                segment_all=False,
+                train_n=3,
+                train_fraction=0.9,
+                validation_fraction=0.9,
+                test_fraction=0.9,  # Total = 2.7, but should be ignored
+            )
         assert config.train_n == 3
 
     def test_train_n_one_is_minimum(self):
@@ -145,37 +148,26 @@ class TestModeSwitch:
 
     def test_same_config_valid_in_fraction_mode_invalid_in_count_mode(self):
         """train_n=0 valid with segment_all=True, invalid with segment_all=False."""
-        # Valid in fraction mode
-        config = TrainingConfig(
-            segment_all=True,
-            train_n=0,
-        )
+        # Valid in fraction mode (warns because train_n differs from default)
+        with pytest.warns(UserWarning, match="train_n.*ignored.*segment_all=True"):
+            config = TrainingConfig(segment_all=True, train_n=0)
         assert config.train_n == 0
 
         # Invalid in count mode
         with pytest.raises(ValueError, match="train_n must be at least 1"):
-            TrainingConfig(
-                segment_all=False,
-                train_n=0,
-            )
+            TrainingConfig(segment_all=False, train_n=0)
 
     def test_invalid_fractions_only_caught_in_fraction_mode(self):
         """Fraction validation only runs when segment_all=True."""
         # Invalid fractions should fail in fraction mode
         with pytest.raises(ValueError, match="must sum to <= 1.0"):
-            TrainingConfig(
-                segment_all=True,
-                train_fraction=0.8,
-                validation_fraction=0.8,
-            )
+            TrainingConfig(segment_all=True, train_fraction=0.8, validation_fraction=0.8)
 
-        # Same invalid fractions should pass in count mode (ignored)
-        config = TrainingConfig(
-            segment_all=False,
-            train_n=5,
-            train_fraction=0.8,
-            validation_fraction=0.8,
-        )
+        # Same invalid fractions should pass in count mode (ignored, with warning)
+        with pytest.warns(UserWarning, match="train_fraction.*ignored.*segment_all=False"):
+            config = TrainingConfig(
+                segment_all=False, train_n=5, train_fraction=0.8, validation_fraction=0.8
+            )
         assert config.train_n == 5
 
 


### PR DESCRIPTION
## Summary

- **Raise `ValueError`** when `train_n + validate_n + test_n` exceeds available images in count mode (`segment_all=False`), replacing the previous silent clamping that caused confusing mismatches between configured and actual split counts
- **Sync fractions after count-mode run**: after `_prepare_processing_units` completes in count mode, `train_fraction`/`validation_fraction`/`test_fraction` are updated in the config to reflect the actual ratios — saved YAML output is now self-consistent regardless of which mode was used
- **Warn when inactive split set has non-default values**: `TrainingConfig.validate_splits` now emits a `UserWarning` when fraction fields are set but `segment_all=False`, or count fields are set but `segment_all=True`, so users get immediate feedback instead of silent ignoring
- **Version bump to 0.3.0**

## Behavior summary

| Scenario | Before | After |
|---|---|---|
| `train_n=10, validate_n=10`, 15 images available | Silently used 10 train + 5 val | `ValueError` with clear message |
| Count-mode run, fractions in saved YAML | Old defaults (0.7/0.3) unrelated to actual split | Actual ratios (e.g. 0.3/0.2) |
| YAML sets `train_fraction=0.5` with `segment_all=False` | Silently ignored | `UserWarning` that fractions are ignored |

## Test plan

- [x] `TestImageCountValidation` — 6 tests covering exact/surplus/insufficient image counts
- [x] `TestFractionSync` — 3 tests verifying fraction values after count-mode runs
- [x] `TestTrainingConfigWarnings` — 5 tests verifying UserWarning behavior
- [x] `test_training_config_validation.py` updated to capture expected warnings
- [x] Full suite: 281 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)