### PR TITLE
fix: upload annotation masks/ROIs to correct OMERO images (glob ordering bug)

### DIFF
--- a/src/omero_annotate_ai/core/annotation_pipeline.py
+++ b/src/omero_annotate_ai/core/annotation_pipeline.py
@@ -748,8 +748,14 @@ class AnnotationPipeline:
             self._debug_print(f"Missing required key: {e}")
             return
 
-        # Get all TIFF files in the annotations directory
-        tiff_files = list(annotations_path.glob("*.tiff")) + list(annotations_path.glob("*.tif"))
+        # Get all TIFF files in the annotations directory.
+        # micro-sam writes seg_00000.tif, seg_00001.tif, ... in the same order
+        # as `images`/`metadata` were passed in. glob() returns arbitrary
+        # filesystem order, so sort by name to realign tiff_files[i] with
+        # metadata[i] (zero-padded names sort numerically).
+        tiff_files = sorted(
+            list(annotations_path.glob("*.tiff")) + list(annotations_path.glob("*.tif"))
+        )
         self._debug_print(f"Found {len(tiff_files)} annotation files for {len(metadata)} metadata entries")
 
         # Process each annotation metadata entry

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -465,6 +465,61 @@ class TestAnnotationPipeline:
         assert unprocessed[0].image_id == 1
         assert processed[0].image_id == 2
 
+    def test_process_annotation_results_pairs_tiff_by_name_not_glob_order(self, tmp_path):
+        """seg_0000i.tif must upload to metadata[i]'s image, regardless of glob order.
+
+        Regression: _process_annotation_results paired metadata[i] with the raw
+        glob() result tiff_files[i]. glob() returns arbitrary filesystem order, so
+        when the filesystem yielded files in reverse, image N received image
+        (count-1-N)'s mask. Here glob is forced to return reverse order to
+        reproduce that failure deterministically.
+        """
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        config = create_default_config()
+        config.workflow.read_only_mode = False
+        config.spatial_coverage.use_patches = False
+        pipeline = AnnotationPipeline(config, conn=Mock())
+
+        # Three annotations + parallel seg files + metadata, all in order 0,1,2
+        annotations_path = tmp_path / "annotations"
+        annotations_path.mkdir()
+        metadata = []
+        for i in range(3):
+            config.add_annotation(
+                ImageAnnotation(image_id=100 + i, image_name=f"img{i}", annotation_id=f"ann{i}")
+            )
+            (annotations_path / f"seg_{i:05d}.tif").write_bytes(b"")
+            metadata.append((f"ann{i}", {"image_id": 100 + i}, i))
+
+        captured = []
+
+        def fake_upload(conn, image_id, annotation_file, **kwargs):
+            captured.append((image_id, Path(annotation_file).name))
+            return (image_id * 10, image_id * 100)
+
+        # Force glob to return descending name order, a valid (worst-case)
+        # filesystem ordering that the buggy positional pairing mishandles.
+        real_glob = Path.glob
+
+        def reversed_glob(self, pattern):
+            return sorted(real_glob(self, pattern), reverse=True)
+
+        with patch(
+            'omero_annotate_ai.core.annotation_pipeline.upload_rois_and_labels',
+            side_effect=fake_upload,
+        ), patch.object(Path, 'glob', reversed_glob):
+            pipeline._process_annotation_results(
+                {"metadata": metadata, "annotations_path": annotations_path}
+            )
+
+        # Each seg_0000i.tif must have been uploaded to image 100+i
+        assert captured == [
+            (100, "seg_00000.tif"),
+            (101, "seg_00001.tif"),
+            (102, "seg_00002.tif"),
+        ]
+
     def test_three_way_split_with_counts(self):
         """Test train/validation/test split with specific counts."""
         config = create_default_config()


### PR DESCRIPTION
## Problem

`_process_annotation_results` paired `metadata[i]` with the raw `glob()` result `tiff_files[i]`:

```python
tiff_files = list(annotations_path.glob("*.tiff")) + list(annotations_path.glob("*.tif"))
...
tiff_file = tiff_files[i] if i < len(tiff_files) else None
```

`glob()` returns **arbitrary filesystem order**, so `seg_0000i.tif` was not guaranteed to line up with `metadata[i]`. When the filesystem yielded files in reverse (observed under `/tmp`), each image received **another image's mask and ROIs** — annotations were uploaded to the wrong OMERO images.

Observed in the annotation widget notebook: `seg_00004.tif → image 24447`, `seg_00003.tif → image 24464`, … the whole batch matched in inverse order.

Not introduced by any recent change — latent since the glob+positional-index code was written; it only surfaced when the filesystem happened to return descending order.

## Fix

Sort the combined glob result by name. micro-sam writes `seg_00000.tif`, `seg_00001.tif`, … in the same order as the `images`/`metadata` passed in, and zero-padded names sort numerically, so sorting realigns `tiff_files[i]` with `metadata[i]`.

## Test

Adds `test_process_annotation_results_pairs_tiff_by_name_not_glob_order` — forces `glob` to return descending order and asserts `seg_0000i.tif` uploads to `metadata[i]`'s image. Fails on old code, passes with the fix. Full `test_pipeline.py` suite: 64 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)