### PR TITLE
fix: harden credential handling in OMERO connection widget

### DIFF
--- a/src/omero_annotate_ai/omero/simple_connection.py
+++ b/src/omero_annotate_ai/omero/simple_connection.py
@@ -1,14 +1,11 @@
 """Simple OMERO connection management with keychain support."""
 
+import configparser
 import json
 import os
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
-
-if TYPE_CHECKING:
-    from omero.gateway import BlitzGateway
-
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     import keyring
@@ -18,13 +15,24 @@ except ImportError:
     KEYRING_AVAILABLE = False
 
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values
 from omero.gateway import BlitzGateway
+
 
 class SimpleOMEROConnection:
     """Simple OMERO connection manager with keychain support for passwords."""
 
     SERVICE_NAME = "omero-annotate-ai"
+
+    # Keys read from ~/.ezomero, mapped to their config names. A ``password``
+    # entry in that file is deliberately not listed: passwords belong in the
+    # keychain, and copying one into the config would spread it to every caller.
+    EZOMERO_KEYS = {
+        "host": "host",
+        "user": "username",
+        "group": "group",
+        "port": "port",
+    }
 
     def __init__(self):
         """Initialize the connection manager."""
@@ -141,109 +149,148 @@ class SimpleOMEROConnection:
             return False
 
     def load_config_files(self) -> Dict[str, Any]:
-        """Load configuration from connection history, .env and .ezomero files.
+        """Load configuration from .env, connection history and .ezomero files.
 
-        Priority order: Connection history -> .env -> .ezomero
+        Priority order: .env -> connection history -> .ezomero
+
+        The returned dictionary never contains a password. Passwords are only
+        ever read from the keychain, via :meth:`load_password`.
 
         Returns:
             Dictionary with configuration parameters
         """
-        config = {}
+        return (
+            self._load_env_config()
+            or self._load_history_config()
+            or self._load_ezomero_config()
+        )
 
-        # Try to load .env file (higher priority than connection history for development)
+    @staticmethod
+    def _coerce_port(value: Any) -> Optional[int]:
+        """Convert a port read from a config file or environment to an int."""
+        if value is None or value == "":
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _load_env_config(self) -> Dict[str, Any]:
+        """Read connection settings from a .env file in the working directory.
+
+        Returns:
+            Dictionary with configuration parameters, empty if none found
+        """
         env_path = Path(".env")
-        if env_path.exists():
-            load_dotenv(env_path, override=False)
-            if os.environ.get("HOST") or os.environ.get("USER_NAME"):
-                config.update(
-                    {
-                        "host": os.environ.get("HOST"),
-                        "username": os.environ.get("USER_NAME"),
-                        "group": os.environ.get("GROUP"),
-                        "source": ".env file",
-                    }
-                )
-                print("Loaded configuration from .env file")
+        if not env_path.exists():
+            return {}
 
-        # Try to load from connection history (if no .env file)
-        if not config:
-            connections = self.load_connection_history()
-            if connections:
-                # Use most recent connection
-                recent_conn = connections[0]
-                # Add display_name if not present
-                if "display_name" not in recent_conn:
-                    recent_conn["display_name"] = (
-                        f"{recent_conn['username']}@{recent_conn['host']}"
-                    )
-                    if recent_conn.get("group"):
-                        recent_conn["display_name"] += f" ({recent_conn['group']})"
+        try:
+            # dotenv_values, not load_dotenv: the file may hold a password, and
+            # load_dotenv would export every entry into os.environ where any
+            # subprocess of this kernel could read it.
+            values = dotenv_values(env_path)
 
-                config.update(
-                    {
-                        "host": recent_conn["host"],
-                        "username": recent_conn["username"],
-                        "group": recent_conn.get("group"),
-                        "source": f"connection history (last used: {recent_conn.get('last_used_display', 'unknown')})",
-                    }
-                )
-                print(
-                    f"Loaded configuration from connection history: {recent_conn['display_name']}"
-                )
+            def lookup(key: str) -> Optional[str]:
+                return values.get(key) or os.environ.get(key)
 
-        # Try to load .ezomero file (if no other config found)
-        if not config:
-            try:
-                # Save current environment to restore later
-                original_env = {}
-                env_keys = [
-                    "OMERO_USER",
-                    "OMERO_PASSWORD",
-                    "OMERO_HOST",
-                    "OMERO_GROUP",
-                    "OMERO_PORT",
-                ]
-                for key in env_keys:
-                    original_env[key] = os.environ.get(key)
+            host = lookup("HOST")
+            username = lookup("USER_NAME")
+            if not host and not username:
+                return {}
 
-                # Temporarily clear ezomero environment variables to force config file loading
-                for key in env_keys:
-                    if key in os.environ:
-                        del os.environ[key]
+            config: Dict[str, Any] = {
+                "host": host,
+                "username": username,
+                "group": lookup("GROUP"),
+                "source": ".env file",
+            }
 
-                # This will attempt to load from .ezomero file and return None (no password)
-                # We don't actually want to create a connection, just test config loading
-                ezomero_home = Path.home() / ".ezomero"
-                if ezomero_home.exists():
-                    # Read .ezomero file directly
-                    import configparser
+            port = self._coerce_port(lookup("PORT"))
+            if port is not None:
+                config["port"] = port
 
-                    parser = configparser.ConfigParser()
-                    parser.read(ezomero_home)
+            print("Loaded configuration from .env file")
+            return config
 
-                    if "default" in parser:
-                        ezomero_config = dict(parser["default"])
-                        # Update config with ezomero values
-                        for key, value in ezomero_config.items():
-                            if value and value.strip():
-                                if key == "user":
-                                    config["username"] = value
-                                else:
-                                    config[key] = value
-                        config["source"] = ".ezomero file"
-                        print("Loaded configuration from .ezomero file")
+        except Exception as e:
+            print(f"Could not load .env file: {e}")
+            return {}
 
-                # Restore original environment
-                for key, value in original_env.items():
-                    if value is not None:
-                        os.environ[key] = value
-                    elif key in os.environ:
-                        del os.environ[key]
+    def _load_history_config(self) -> Dict[str, Any]:
+        """Read connection settings from the most recent saved connection.
 
-            except Exception as e:
-                print(f"Could not load .ezomero file: {e}")
+        Returns:
+            Dictionary with configuration parameters, empty if none found
+        """
+        try:
+            connections = self.get_connection_list()
+            if not connections:
+                return {}
 
-        return config
+            recent = connections[0]
+            print(
+                f"Loaded configuration from connection history: {recent['display_name']}"
+            )
+            config: Dict[str, Any] = {
+                "host": recent["host"],
+                "username": recent["username"],
+                "group": recent.get("group"),
+                "source": (
+                    f"connection history (last used: {recent['last_used_display']})"
+                ),
+            }
+
+            port = self._coerce_port(recent.get("port"))
+            if port is not None:
+                config["port"] = port
+
+            return config
+
+        except Exception as e:
+            print(f"Could not load connection history: {e}")
+            return {}
+
+    def _load_ezomero_config(self) -> Dict[str, Any]:
+        """Read connection settings from ~/.ezomero.
+
+        Only the keys in :attr:`EZOMERO_KEYS` are read, so a ``password`` entry
+        in that file is ignored rather than copied into the returned config.
+
+        Returns:
+            Dictionary with configuration parameters, empty if none found
+        """
+        ezomero_path = Path.home() / ".ezomero"
+        if not ezomero_path.exists():
+            return {}
+
+        try:
+            parser = configparser.ConfigParser()
+            parser.read(ezomero_path)
+
+            if "default" not in parser:
+                return {}
+
+            config: Dict[str, Any] = {}
+            for file_key, config_key in self.EZOMERO_KEYS.items():
+                value = parser["default"].get(file_key)
+                if value and value.strip():
+                    config[config_key] = value.strip()
+
+            if not config:
+                return {}
+
+            port = self._coerce_port(config.pop("port", None))
+            if port is not None:
+                config["port"] = port
+
+            config["source"] = ".ezomero file"
+            print("Loaded configuration from .ezomero file")
+            return config
+
+        except Exception as e:
+            print(f"Could not load .ezomero file: {e}")
+            return {}
 
     def connect(
         self,
@@ -313,6 +360,7 @@ class SimpleOMEROConnection:
         password: str,
         group: Optional[str] = None,
         secure: bool = True,
+        port: Optional[int] = None,
     ) -> Tuple[bool, str]:
         """Test OMERO connection without keeping it open.
 
@@ -322,12 +370,13 @@ class SimpleOMEROConnection:
             password: OMERO password
             group: OMERO group (optional)
             secure: Use secure connection (default True)
+            port: OMERO server port (optional)
 
         Returns:
             Tuple of (success, message)
         """
         try:
-            conn = self.connect(host, username, password, group, secure)
+            conn = self.connect(host, username, password, group, secure, port=port)
             if conn:
                 # Close test connection
                 conn.close()
@@ -342,20 +391,23 @@ class SimpleOMEROConnection:
     ) -> Optional[Any]:
         """Create connection from widget configuration.
 
+        The password is never persisted here. Callers that want to store it
+        must call :meth:`save_password` themselves, so that they can report
+        whether the keychain write actually succeeded.
+
         Args:
             widget_config: Configuration dictionary from widget
 
         Returns:
             BlitzGateway connection object if successful, None otherwise
         """
-        host = widget_config.get("host", "").strip()
-        username = widget_config.get("username", "").strip()
-        password = widget_config.get("password", "").strip()
-        group = widget_config.get("group", "").strip() or None
+        host = (widget_config.get("host") or "").strip()
+        username = (widget_config.get("username") or "").strip()
+        # Not stripped: whitespace can be part of a password.
+        password = widget_config.get("password") or ""
+        group = (widget_config.get("group") or "").strip() or None
         secure = widget_config.get("secure", True)
         port = widget_config.get("port")
-        save_password = widget_config.get("save_password", False)
-        expire_hours = widget_config.get("expire_hours")
 
         # Validate required fields
         if not host or not username or not password:
@@ -374,16 +426,12 @@ class SimpleOMEROConnection:
         )
 
         if connection:
-            # Save password to keychain if requested
-            if save_password:
-                self.save_password(host, username, password, expire_hours)
-
-            # Always save connection details for successful connections
-            self.save_connection_details(host, username, group, verbose=False)
+            # Remember host/username/group/port (never the password) for next time
+            self.save_connection_details(host, username, group, port, verbose=False)
 
         return connection
 
-    def get_last_connection(self) -> Optional["BlitzGateway"]:
+    def get_last_connection(self) -> Optional[BlitzGateway]:
         """Get the last successful connection.
 
         Returns:
@@ -414,14 +462,19 @@ class SimpleOMEROConnection:
         host: str,
         username: str,
         group: Optional[str] = None,
+        port: Optional[int] = None,
         verbose: bool = True,
     ) -> bool:
         """Save connection details to history file.
+
+        Never stores a password: only the keychain does that.
 
         Args:
             host: OMERO server host
             username: OMERO username
             group: OMERO group (optional)
+            port: OMERO server port (optional)
+            verbose: Print a confirmation message
 
         Returns:
             True if saved successfully, False otherwise
@@ -440,6 +493,7 @@ class SimpleOMEROConnection:
                 "host": host,
                 "username": username,
                 "group": group,
+                "port": port,
                 "last_used": datetime.now(timezone.utc).isoformat(),
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }

--- a/src/omero_annotate_ai/omero/simple_connection.py
+++ b/src/omero_annotate_ai/omero/simple_connection.py
@@ -260,11 +260,13 @@ class SimpleOMEROConnection:
         Returns:
             Dictionary with configuration parameters, empty if none found
         """
-        ezomero_path = Path.home() / ".ezomero"
-        if not ezomero_path.exists():
-            return {}
-
         try:
+            # Path.home() raises RuntimeError on Windows when the environment
+            # has no USERPROFILE/HOMEPATH, so it belongs inside the guard.
+            ezomero_path = Path.home() / ".ezomero"
+            if not ezomero_path.exists():
+                return {}
+
             parser = configparser.ConfigParser()
             parser.read(ezomero_path)
 

--- a/src/omero_annotate_ai/widgets/omero_connection_widget.py
+++ b/src/omero_annotate_ai/widgets/omero_connection_widget.py
@@ -1,6 +1,6 @@
 """Interactive widget for OMERO server connections with keychain support."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import ipywidgets as widgets
 from IPython.display import clear_output, display
@@ -11,10 +11,14 @@ from ..omero.simple_connection import SimpleOMEROConnection
 class OMEROConnectionWidget:
     """Interactive widget for creating OMERO connections with secure password storage."""
 
+    DEFAULT_PORT = 4064
+
     def __init__(self):
         """Initialize the OMERO connection widget."""
         self.connection_manager = SimpleOMEROConnection()
         self.connection = None
+        self._connections_by_key: Dict[str, Dict[str, Any]] = {}
+        self._suppress_dropdown_events = False
         self._create_widgets()
         self._setup_observers()
         self._load_existing_config()
@@ -24,12 +28,7 @@ class OMEROConnectionWidget:
 
         # Header
         self.header = widgets.HTML(
-            value="""
-                <h3>🔌 OMERO Server Connection</h3>
-                <div style='font-size:90%;color:#888;margin-top:-10px;'>
-                    <b>Note:</b> If your OMERO server uses a non-default port, add it to the host as <code>host:port</code> (e.g., <code>localhost:6064</code>).
-                </div>
-            """,
+            value="<h3>🔌 OMERO Server Connection</h3>",
             layout=widgets.Layout(margin="0 0 20px 0"),
         )
 
@@ -46,6 +45,14 @@ class OMEROConnectionWidget:
         self.host_widget = widgets.Text(
             description="Host:",
             placeholder="omero.server.edu",
+            style={"description_width": "initial"},
+        )
+
+        self.port_widget = widgets.BoundedIntText(
+            value=self.DEFAULT_PORT,
+            min=1,
+            max=65535,
+            description="Port:",
             style={"description_width": "initial"},
         )
 
@@ -78,7 +85,7 @@ class OMEROConnectionWidget:
             value=False,
             description="Save password to keychain",
             style={"description_width": "initial"},
-            tooltip="When checked, your password will be securely saved and auto-loaded for future connections to this server"
+            tooltip="When checked, your password will be securely saved and auto-loaded for future connections to this server",
         )
 
         self.expire_widget = widgets.Dropdown(
@@ -93,13 +100,6 @@ class OMEROConnectionWidget:
             description="Remember for:",
             style={"description_width": "initial"},
             disabled=True,
-        )
-
-        # Show password toggle
-        self.show_password_widget = widgets.Checkbox(
-            value=False,
-            description="Show password",
-            style={"description_width": "initial"},
         )
 
         # Action buttons
@@ -138,6 +138,7 @@ class OMEROConnectionWidget:
         connection_fields = widgets.VBox(
             [
                 self.host_widget,
+                self.port_widget,
                 self.username_widget,
                 self.password_widget,
                 self.group_widget,
@@ -147,10 +148,11 @@ class OMEROConnectionWidget:
 
         password_options = widgets.VBox(
             [
-                widgets.HTML("<b>Password Options</b><br><i>Note: Passwords are only saved to keychain when explicitly requested</i>"),
-                self.save_password_widget, 
-                self.expire_widget, 
-                self.show_password_widget
+                widgets.HTML(
+                    "<b>Password Options</b><br><i>Note: Passwords are only saved to keychain when explicitly requested</i>"
+                ),
+                self.save_password_widget,
+                self.expire_widget,
             ]
         )
 
@@ -185,11 +187,6 @@ class OMEROConnectionWidget:
         # Enable/disable expire dropdown based on save password checkbox
         self.save_password_widget.observe(self._toggle_expire_options, names="value")
 
-        # Show/hide password
-        self.show_password_widget.observe(
-            self._toggle_password_visibility, names="value"
-        )
-
         # Connection dropdown observer
         self.connection_dropdown.observe(self._on_connection_selected, names="value")
 
@@ -204,199 +201,262 @@ class OMEROConnectionWidget:
         """Toggle expiration dropdown based on save password checkbox."""
         self.expire_widget.disabled = not change["new"]
 
-    def _toggle_password_visibility(self, change):
-        """Toggle password visibility."""
-        if change["new"]:
-            # Show password - convert to text widget
-            password_value = self.password_widget.value
-            self.password_widget.close()
+    @staticmethod
+    def _connection_key(host: str, username: str) -> str:
+        """Build the stable identifier used for a saved connection."""
+        return f"{host}:{username}"
 
-            self.password_widget = widgets.Text(
-                value=password_value,
-                description="Password:",
-                placeholder="Enter password",
-                style={"description_width": "initial"},
-            )
-        else:
-            # Hide password - convert to password widget
-            password_value = self.password_widget.value
-            self.password_widget.close()
-
-            self.password_widget = widgets.Password(
-                value=password_value,
-                description="Password:",
-                placeholder="Enter password",
-                style={"description_width": "initial"},
-            )
-
-        # Update the container (find and replace the password widget)
-        connection_fields = self.main_widget.children[3]  # Connection fields VBox
-        children_list = list(connection_fields.children)
-        children_list[2] = self.password_widget  # Password is 3rd field
-        connection_fields.children = tuple(children_list)
+    @staticmethod
+    def _expire_text(expire_hours: Optional[int]) -> str:
+        """Describe a keychain expiry period for display."""
+        if expire_hours:
+            return f" (expires in {expire_hours} hours)"
+        return " (no expiration)"
 
     def _load_existing_config(self):
-        """Load existing configuration and populate connection dropdown."""
-        # Load connection history for dropdown
+        """Load existing configuration and pre-populate the connection fields."""
+        config = self.connection_manager.load_config_files() or {}
+
+        if not config:
+            self.config_info.value = "<i>💡 No existing configuration found</i>"
+            self._populate_connection_dropdown()
+            return
+
+        # `config.get(key, "")` is not enough here: a key can be present with a
+        # None value when only some of the fields are set in .env.
+        self.host_widget.value = (config.get("host") or "").strip()
+        self.username_widget.value = (config.get("username") or "").strip()
+        self.group_widget.value = (config.get("group") or "").strip()
+
+        port = self._parse_port(config.get("port"))
+        if port is not None:
+            self.port_widget.value = port
+
+        # The password is deliberately not loaded here. ipywidgets stores widget
+        # values in the notebook's saved state, so auto-filling it would put a
+        # password the user never typed into the .ipynb. Use "Load from Keychain".
+        source = config.get("source", "configuration files")
+        self.config_info.value = f"<i>Pre-populated from {source}</i>"
+
         self._populate_connection_dropdown()
 
-        # Load default configuration
-        config = self.connection_manager.load_config_files()
-
-        if config:
-            # Pre-populate fields
-            if config.get("host"):
-                self.host_widget.value = config["host"]
-            if config.get("username"):
-                self.username_widget.value = config["username"]
-            if config.get("group"):
-                self.group_widget.value = config["group"]
-
-            # Automatically try to load password from keychain if host and username are available
-            host = config.get("host", "").strip()
-            username = config.get("username", "").strip()
-            password_loaded = False
-
-            if host and username:
-                password = self.connection_manager.load_password(host, username)
-                if password:
-                    self.password_widget.value = password
-                    password_loaded = True
-                    with self.status_output:
-                        clear_output()
-                        print("🔐 Password automatically loaded from keychain")
-
-            # Show config source
-            source = config.get("source", "configuration files")
-            sources = [source]
-            if password_loaded:
-                sources.append("keychain")
-
-            self.config_info.value = (
-                f"<i>Pre-populated from {' + '.join(sources)}</i>"
-            )
-        else:
-            self.config_info.value = "<i>💡 No existing configuration found</i>"
+    def _parse_port(self, value: Any) -> Optional[int]:
+        """Coerce a port from a config file into a value the widget accepts."""
+        try:
+            port = int(value)
+        except (TypeError, ValueError):
+            return None
+        return port if 1 <= port <= 65535 else None
 
     def _populate_connection_dropdown(self):
         """Populate the connection dropdown with saved connections."""
         connections = self.connection_manager.get_connection_list()
 
-        # Create dropdown options
-        options = [("Manual entry", None)]
+        # Dropdown values are stable "host:username" keys rather than the
+        # connection dicts themselves, which are rebuilt on every refresh.
+        self._connections_by_key = {
+            self._connection_key(conn["host"], conn["username"]): conn
+            for conn in connections
+        }
 
-        for conn in connections:
+        options = [("Manual entry", None)]
+        for key, conn in self._connections_by_key.items():
             display_text = (
                 f"{conn['display_name']} (last used: {conn['last_used_display']})"
             )
-            options.append((display_text, conn))
+            options.append((display_text, key))
 
-        # Update dropdown
-        self.connection_dropdown.options = options
+        # Re-select whichever saved connection matches the current form fields
+        current_key = self._connection_key(
+            self.host_widget.value.strip(), self.username_widget.value.strip()
+        )
+        selected = current_key if current_key in self._connections_by_key else None
 
-        # Check if current form fields match any saved connection
-        current_host = self.host_widget.value.strip()
-        current_username = self.username_widget.value.strip()
+        # Refreshing the dropdown is not a user action, so it must not run the
+        # selection handler - that would read the keychain behind the user's back.
+        self._suppress_dropdown_events = True
+        try:
+            self.connection_dropdown.options = options
+            self.connection_dropdown.value = selected
+        finally:
+            self._suppress_dropdown_events = False
 
-        if current_host and current_username:
-            # Look for matching connection
-            for display_text, conn in options[1:]:  # Skip 'Manual entry'
-                if (
-                    conn
-                    and conn["host"] == current_host
-                    and conn["username"] == current_username
-                ):
-                    self.connection_dropdown.value = conn
-                    self.delete_connection_button.disabled = False
-                    return
+        self.delete_connection_button.disabled = selected is None
 
-        # If no match found, select manual entry
-        self.connection_dropdown.value = None
-        self.delete_connection_button.disabled = True
+    def _on_connection_selected(self, change):
+        """Handle connection selection from dropdown."""
+        if self._suppress_dropdown_events:
+            return
+
+        selected_key = change["new"]
+        connection = (
+            self._connections_by_key.get(selected_key) if selected_key else None
+        )
+
+        if connection is None:
+            # Manual entry selected
+            self.delete_connection_button.disabled = True
+            return
+
+        # Populate fields from selected connection
+        self.host_widget.value = connection["host"]
+        self.username_widget.value = connection["username"]
+        self.group_widget.value = connection.get("group") or ""
+
+        port = self._parse_port(connection.get("port"))
+        self.port_widget.value = port if port is not None else self.DEFAULT_PORT
+
+        self.delete_connection_button.disabled = False
+
+        # Picking a connection is an explicit user action, so loading its stored
+        # password here is expected rather than surprising.
+        self.password_widget.value = ""
+        with self.status_output:
+            clear_output()
+            try:
+                self._load_password_into_field(
+                    connection["host"], connection["username"]
+                )
+            except Exception as e:
+                print(f"❌ Error loading password from keychain: {e}")
+
+    def _load_password_into_field(self, host: str, username: str) -> bool:
+        """Load a stored password from the keychain into the password field.
+
+        Args:
+            host: OMERO server host
+            username: OMERO username
+
+        Returns:
+            True if a password was found and filled in, False otherwise
+        """
+        password = self.connection_manager.load_password(host, username)
+        if not password:
+            print(f"💡 No saved password found for {username}@{host}")
+            return False
+
+        self.password_widget.value = password
+        print(f"🔐 Password loaded from keychain for {username}@{host}")
+        return True
 
     def _load_from_keychain(self, button):
         """Load password from keychain."""
         with self.status_output:
             clear_output()
+            try:
+                host = self.host_widget.value.strip()
+                username = self.username_widget.value.strip()
 
-            host = self.host_widget.value.strip()
-            username = self.username_widget.value.strip()
+                if not host or not username:
+                    print("❌ Please enter host and username first")
+                    return
 
-            if not host or not username:
-                print("Please enter host and username first")
-                return
+                self._load_password_into_field(host, username)
 
-            password = self.connection_manager.load_password(host, username)
-            if password:
-                self.password_widget.value = password
-                print("Password loaded from keychain")
-            else:
-                print("No password found in keychain for this host/username")
+            except Exception as e:
+                print(f"❌ Error loading password from keychain: {e}")
 
     def _test_connection(self, button):
         """Test the OMERO connection."""
         with self.status_output:
             clear_output()
+            try:
+                config = self._get_widget_config()
+                if not self._validate_config(config):
+                    return
 
-            config = self._get_widget_config()
-            if not self._validate_config(config):
-                return
+                print("🔌 Testing connection...")
+                success, message = self.connection_manager.test_connection(
+                    config["host"],
+                    config["username"],
+                    config["password"],
+                    config["group"],
+                    config["secure"],
+                    config["port"],
+                )
 
-            print("🔌 Testing connection...")
-            success, message = self.connection_manager.test_connection(
-                config["host"],
-                config["username"],
-                config["password"],
-                config["group"],
-                config["secure"],
-            )
+                print(f"{'✅' if success else '❌'} {message}")
 
-            if success:
-                print(f"{message}")
-            else:
-                print(f"{message}")
+            except Exception as e:
+                print(f"❌ Error testing connection: {e}")
 
     def _connect(self, button):
         """Create connection and optionally save password if requested."""
         with self.status_output:
             clear_output()
+            try:
+                config = self._get_widget_config()
+                if not self._validate_config(config):
+                    return
 
-            config = self._get_widget_config()
-            if not self._validate_config(config):
-                return
+                # Don't leak the previous gateway and its keep-alive thread
+                self._close_existing_connection()
 
-            print("🔌 Creating connection...")
-            self.connection = self.connection_manager.create_connection_from_config(
-                config
-            )
+                print("🔌 Creating connection...")
+                self.connection = (
+                    self.connection_manager.create_connection_from_config(config)
+                )
 
-            if self.connection:
-                print("Connection created and ready to use!")
-                # Show user info
-                print(f"👤 User: {self.connection.getUser().getName()}")
-                print(f"🏢 Group: {self.connection.getGroupFromContext().getName()}")
+                if not self.connection:
+                    print("❌ Failed to create connection")
+                    return
+
+                print("✅ Connection created and ready to use!")
+                self._print_connection_details()
                 print("💾 Connection details saved to history")
-                
-                # Show password saving status
-                if config["save_password"]:
-                    expire_text = f" (expires in {config['expire_hours']} hours)" if config['expire_hours'] else " (no expiration)"
-                    print(f"🔐 Password saved to keychain{expire_text}")
-                else:
-                    print("🔓 Password not saved (keychain saving was not requested)")
-            else:
-                print("❌ Failed to create connection")
+                self._persist_password(config)
 
-    def _save_and_connect(self, button):
-        """Alias for _connect method for backward compatibility."""
-        return self._connect(button)
+            except Exception as e:
+                print(f"❌ Error creating connection: {e}")
+
+    def _close_existing_connection(self):
+        """Close a connection this widget opened earlier, if any."""
+        if self.connection is None:
+            return
+
+        try:
+            self.connection.close()
+        except Exception as e:
+            print(f"⚠️ Could not close previous connection: {e}")
+        finally:
+            self.connection = None
+
+    def _print_connection_details(self):
+        """Show who we connected as, without failing an otherwise good connection."""
+        try:
+            print(f"👤 User: {self.connection.getUser().getName()}")
+            print(f"🏢 Group: {self.connection.getGroupFromContext().getName()}")
+        except Exception as e:
+            print(f"⚠️ Connected, but could not read user/group details: {e}")
+
+    def _persist_password(self, config: Dict[str, Any]):
+        """Save the password to the keychain if the user asked for it."""
+        if not config["save_password"]:
+            print("🔓 Password not saved (keychain saving was not requested)")
+            return
+
+        saved = self.connection_manager.save_password(
+            config["host"],
+            config["username"],
+            config["password"],
+            config["expire_hours"],
+        )
+
+        if saved:
+            expire_text = self._expire_text(config["expire_hours"])
+            print(f"🔐 Password saved to keychain{expire_text}")
+        else:
+            print("⚠️ Password could NOT be saved to keychain")
 
     def _get_widget_config(self) -> Dict[str, Any]:
-        """Get configuration from widget values."""
+        """Get configuration from widget values, including the plaintext password."""
         return {
             "host": self.host_widget.value.strip(),
             "username": self.username_widget.value.strip(),
-            "password": self.password_widget.value.strip(),
+            # Not stripped: whitespace can be a legitimate part of a password.
+            "password": self.password_widget.value,
             "group": self.group_widget.value.strip(),
+            "port": self.port_widget.value,
             "secure": self.secure_widget.value,
             "save_password": self.save_password_widget.value,
             "expire_hours": self.expire_widget.value,
@@ -415,113 +475,89 @@ class OMEROConnectionWidget:
             return False
         return True
 
-    def _on_connection_selected(self, change):
-        """Handle connection selection from dropdown."""
-        selected_connection = change["new"]
-
-        if selected_connection is None:
-            # Manual entry selected
-            self.delete_connection_button.disabled = True
-            return
-
-        # Populate fields from selected connection
-        self.host_widget.value = selected_connection["host"]
-        self.username_widget.value = selected_connection["username"]
-        self.group_widget.value = selected_connection.get("group", "") or ""
-
-        # Enable delete button
-        self.delete_connection_button.disabled = False
-
-        # Try to load password from keychain
-        host = selected_connection["host"]
-        username = selected_connection["username"]
-        password = self.connection_manager.load_password(host, username)
-
-        if password:
-            self.password_widget.value = password
-            with self.status_output:
-                clear_output()
-                print(f"🔐 Password loaded from keychain for {username}@{host}")
-        else:
-            self.password_widget.value = ""
-            with self.status_output:
-                clear_output()
-                print(f"💡 No saved password found for {username}@{host}")
-
     def _save_connection_only(self, button):
         """Save connection details without creating a connection."""
         with self.status_output:
             clear_output()
+            try:
+                host = self.host_widget.value.strip()
+                username = self.username_widget.value.strip()
+                group = self.group_widget.value.strip() or None
+                port = self.port_widget.value
 
-            host = self.host_widget.value.strip()
-            username = self.username_widget.value.strip()
-            group = self.group_widget.value.strip() or None
+                if not host or not username:
+                    print("❌ Host and username are required to save connection")
+                    return
 
-            if not host or not username:
-                print("❌ Host and username are required to save connection")
-                return
+                if not self.connection_manager.save_connection_details(
+                    host, username, group, port
+                ):
+                    print("❌ Failed to save connection")
+                    return
 
-            # Save connection details
-            success = self.connection_manager.save_connection_details(
-                host, username, group
-            )
-
-            if success:
-                # Save password if requested
-                if self.save_password_widget.value:
-                    password = self.password_widget.value.strip()
-                    if password:
-                        expire_hours = self.expire_widget.value
-                        self.connection_manager.save_password(
-                            host, username, password, expire_hours
-                        )
-                        expire_text = f" (expires in {expire_hours} hours)" if expire_hours else " (no expiration)"
-                        print(f"🔐 Password saved to keychain{expire_text}")
-                    else:
-                        print("⚠️ Password not saved - password field is empty")
-                else:
-                    print("🔓 Password not saved to keychain (not requested)")
+                self._save_password_if_requested(host, username)
 
                 # Refresh dropdown
                 self._populate_connection_dropdown()
                 print("✅ Connection saved successfully!")
-            else:
-                print("❌ Failed to save connection")
+
+            except Exception as e:
+                print(f"❌ Error saving connection: {e}")
+
+    def _save_password_if_requested(self, host: str, username: str):
+        """Save the current password to the keychain if the user asked for it."""
+        if not self.save_password_widget.value:
+            print("🔓 Password not saved to keychain (not requested)")
+            return
+
+        password = self.password_widget.value
+        if not password:
+            print("⚠️ Password not saved - password field is empty")
+            return
+
+        expire_hours = self.expire_widget.value
+        if self.connection_manager.save_password(
+            host, username, password, expire_hours
+        ):
+            print(f"🔐 Password saved to keychain{self._expire_text(expire_hours)}")
+        else:
+            print("⚠️ Password could NOT be saved to keychain")
 
     def _delete_connection(self, button):
         """Delete the selected connection."""
         with self.status_output:
             clear_output()
+            try:
+                selected_key = self.connection_dropdown.value
+                connection = (
+                    self._connections_by_key.get(selected_key) if selected_key else None
+                )
 
-            selected_connection = self.connection_dropdown.value
-            if selected_connection is None:
-                print("❌ No connection selected for deletion")
-                return
+                if connection is None:
+                    print("❌ No connection selected for deletion")
+                    return
 
-            host = selected_connection["host"]
-            username = selected_connection["username"]
+                host = connection["host"]
+                username = connection["username"]
 
-            # Confirm deletion
-            print(f"🗑️ Deleting connection: {username}@{host}")
+                print(f"🗑️ Deleting connection: {username}@{host}")
 
-            success = self.connection_manager.delete_connection(host, username)
+                if not self.connection_manager.delete_connection(host, username):
+                    print("❌ Failed to delete connection")
+                    return
 
-            if success:
-                # Refresh dropdown
-                self._populate_connection_dropdown()
-
-                # Clear fields
+                # Clear fields before refreshing, so nothing re-selects the entry
                 self.host_widget.value = ""
                 self.username_widget.value = ""
                 self.password_widget.value = ""
                 self.group_widget.value = ""
+                self.port_widget.value = self.DEFAULT_PORT
 
-                # Select manual entry
-                self.connection_dropdown.value = None
-
+                self._populate_connection_dropdown()
                 print("✅ Connection deleted successfully!")
-            else:
-                print("❌ Failed to delete connection")
+
+            except Exception as e:
+                print(f"❌ Error deleting connection: {e}")
 
     def display(self):
         """Display the widget."""
@@ -535,13 +571,22 @@ class OMEROConnectionWidget:
         """
         return self.connection
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self, include_password: bool = False) -> Dict[str, Any]:
         """Get the current widget configuration.
+
+        The password is left out by default: printing the returned dictionary in
+        a notebook would otherwise write it into the saved .ipynb.
+
+        Args:
+            include_password: Include the plaintext password in the result
 
         Returns:
             Configuration dictionary
         """
-        return self._get_widget_config()
+        config = self._get_widget_config()
+        if not include_password:
+            config.pop("password", None)
+        return config
 
 
 def create_omero_connection_widget() -> OMEROConnectionWidget:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,18 @@ except ImportError:
 # Simple Shared Fixtures
 # =============================================================================
 
+@pytest.fixture(autouse=True)
+def isolated_cwd(tmp_path, monkeypatch):
+    """Run every test in a throwaway working directory.
+
+    Several config paths are relative - OutputConfig.output_directory defaults
+    to ./annotations, and SimpleOMEROConnection reads ./.env - so a test that
+    triggers an auto-save would otherwise write into the checked-out repo and
+    dirty the working tree. Isolating the cwd makes that structurally impossible.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.fixture
 def sample_config():
     """Basic configuration for testing."""

--- a/tests/test_simple_connection.py
+++ b/tests/test_simple_connection.py
@@ -1,0 +1,241 @@
+"""Tests for SimpleOMEROConnection credential and config handling.
+
+These are unit tests: no OMERO server is contacted. They focus on the paths
+where a secret could escape - the keychain, ``.env`` and ``~/.ezomero``.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+try:
+    from omero_annotate_ai.omero.simple_connection import SimpleOMEROConnection
+
+    CONNECTION_AVAILABLE = True
+except ImportError:
+    CONNECTION_AVAILABLE = False
+
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.skipif(
+        not CONNECTION_AVAILABLE, reason="OMERO dependencies not available"
+    ),
+]
+
+
+class FakeKeyring:
+    """In-memory stand-in for the ``keyring`` module."""
+
+    def __init__(self):
+        self.store = {}
+
+    def set_password(self, service, key, value):
+        self.store[(service, key)] = value
+
+    def get_password(self, service, key):
+        return self.store.get((service, key))
+
+    def delete_password(self, service, key):
+        del self.store[(service, key)]
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch):
+    """Replace the real OS keyring with an in-memory one."""
+    import omero_annotate_ai.omero.simple_connection as sc
+
+    keyring = FakeKeyring()
+    monkeypatch.setattr(sc, "keyring", keyring, raising=False)
+    monkeypatch.setattr(sc, "KEYRING_AVAILABLE", True)
+    return keyring
+
+
+@pytest.fixture
+def manager(tmp_path, monkeypatch):
+    """A connection manager with an isolated home directory.
+
+    The cwd is already isolated by the autouse ``isolated_cwd`` fixture, so the
+    ``.env`` files these tests write land in a throwaway directory.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+
+    return SimpleOMEROConnection()
+
+
+class TestKeychain:
+    """Passwords are stored in the keychain and honour their expiry."""
+
+    def test_save_and_load_round_trip(self, manager, fake_keyring):
+        assert manager.save_password("omero.example.org", "alice", "  s3 cret  ")
+
+        loaded = manager.load_password("omero.example.org", "alice")
+        assert loaded == "  s3 cret  "
+
+    def test_expired_password_is_dropped_and_deleted(self, manager, fake_keyring):
+        manager.save_password("omero.example.org", "alice", "s3cret", expire_hours=-1)
+
+        assert manager.load_password("omero.example.org", "alice") is None
+        # The expired secret must be purged, not just hidden
+        assert fake_keyring.store == {}
+
+    def test_unexpired_password_survives(self, manager, fake_keyring):
+        manager.save_password("omero.example.org", "alice", "s3cret", expire_hours=24)
+
+        assert manager.load_password("omero.example.org", "alice") == "s3cret"
+
+    def test_delete_connection_purges_the_password(self, manager, fake_keyring):
+        manager.save_connection_details("omero.example.org", "alice")
+        manager.save_password("omero.example.org", "alice", "s3cret")
+
+        assert manager.delete_connection("omero.example.org", "alice")
+        assert fake_keyring.store == {}
+
+    def test_save_reports_failure_without_a_keyring(self, manager, monkeypatch):
+        import omero_annotate_ai.omero.simple_connection as sc
+
+        monkeypatch.setattr(sc, "KEYRING_AVAILABLE", False)
+
+        assert manager.save_password("omero.example.org", "alice", "s3cret") is False
+
+
+class TestEnvConfig:
+    """.env is read, but never exported into the process environment."""
+
+    def test_password_in_env_file_is_not_leaked(self, manager, monkeypatch):
+        monkeypatch.delenv("PASSWORD", raising=False)
+        Path(".env").write_text(
+            "HOST=omero.example.org\nUSER_NAME=alice\nPASSWORD=s3cret\n"
+        )
+
+        config = manager.load_config_files()
+
+        assert config["host"] == "omero.example.org"
+        assert config["username"] == "alice"
+        # The password must reach neither the config dict nor os.environ, where
+        # every subprocess of the kernel would be able to read it.
+        assert "password" not in config
+        assert "PASSWORD" not in os.environ
+
+    def test_env_file_does_not_pollute_os_environ(self, manager, monkeypatch):
+        monkeypatch.delenv("HOST", raising=False)
+        Path(".env").write_text("HOST=omero.example.org\nUSER_NAME=alice\n")
+
+        manager.load_config_files()
+
+        assert "HOST" not in os.environ
+
+    def test_port_is_parsed_to_int(self, manager):
+        Path(".env").write_text("HOST=omero.example.org\nUSER_NAME=alice\nPORT=6064\n")
+
+        assert manager.load_config_files()["port"] == 6064
+
+    def test_username_without_host(self, manager):
+        """Regression: a partial .env must not crash the caller."""
+        Path(".env").write_text("USER_NAME=alice\n")
+
+        config = manager.load_config_files()
+
+        assert config["username"] == "alice"
+        assert config["host"] is None
+
+
+class TestEzomeroConfig:
+    """~/.ezomero is read through a whitelist."""
+
+    def test_password_in_ezomero_is_ignored(self, manager):
+        (Path.home() / ".ezomero").write_text(
+            "[default]\n"
+            "host=omero.example.org\n"
+            "user=alice\n"
+            "group=lab\n"
+            "port=6064\n"
+            "password=s3cret\n"
+        )
+
+        config = manager.load_config_files()
+
+        assert config["host"] == "omero.example.org"
+        assert config["username"] == "alice"
+        assert config["group"] == "lab"
+        assert config["port"] == 6064
+        assert "password" not in config
+
+    def test_malformed_ezomero_preserves_the_environment(self, manager, monkeypatch):
+        """Regression: a parse failure used to permanently drop OMERO_* env vars."""
+        monkeypatch.setenv("OMERO_PASSWORD", "from-env")
+        monkeypatch.setenv("OMERO_HOST", "omero.example.org")
+        (Path.home() / ".ezomero").write_text("this is not valid ini [[[\n")
+
+        assert manager.load_config_files() == {}
+
+        assert os.environ["OMERO_PASSWORD"] == "from-env"
+        assert os.environ["OMERO_HOST"] == "omero.example.org"
+
+
+class TestConnectionHistory:
+    """Connection history stores metadata only, never a password."""
+
+    def test_history_file_holds_no_secret(self, manager, fake_keyring):
+        manager.save_connection_details("omero.example.org", "alice", "lab", 6064)
+        manager.save_password("omero.example.org", "alice", "s3cret")
+
+        raw = (Path.home() / ".omero-annotate-ai" / "connections.json").read_text()
+
+        assert "s3cret" not in raw
+        entry = json.loads(raw)[0]
+        assert entry["host"] == "omero.example.org"
+        assert entry["port"] == 6064
+
+    def test_history_round_trips_the_port(self, manager):
+        manager.save_connection_details("omero.example.org", "alice", None, 6064)
+
+        config = manager.load_config_files()
+
+        assert config["port"] == 6064
+        assert config["source"].startswith("connection history")
+
+    def test_env_file_takes_priority_over_history(self, manager):
+        manager.save_connection_details("history.example.org", "bob")
+        Path(".env").write_text("HOST=env.example.org\nUSER_NAME=alice\n")
+
+        assert manager.load_config_files()["host"] == "env.example.org"
+
+
+class TestCreateConnectionFromConfig:
+    """The manager connects, but does not quietly persist secrets."""
+
+    def test_password_is_not_stripped(self, manager, monkeypatch):
+        seen = {}
+
+        def fake_connect(host, username, password, group=None, secure=True, **kwargs):
+            seen["password"] = password
+            return None
+
+        monkeypatch.setattr(manager, "connect", fake_connect)
+
+        manager.create_connection_from_config(
+            {"host": "omero.example.org", "username": "alice", "password": "  s3 cret  "}
+        )
+
+        assert seen["password"] == "  s3 cret  "
+
+    def test_does_not_write_to_the_keychain(self, manager, fake_keyring, monkeypatch):
+        """Persisting the password is the caller's job, so it can report failures."""
+        monkeypatch.setattr(manager, "connect", lambda *a, **kw: object())
+
+        manager.create_connection_from_config(
+            {
+                "host": "omero.example.org",
+                "username": "alice",
+                "password": "s3cret",
+                "save_password": True,
+                "expire_hours": 24,
+            }
+        )
+
+        assert fake_keyring.store == {}

--- a/tests/test_simple_connection.py
+++ b/tests/test_simple_connection.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 try:
-    from omero_annotate_ai.omero.simple_connection import SimpleOMEROConnection
+    import omero_annotate_ai.omero.simple_connection as sc
 
     CONNECTION_AVAILABLE = True
 except ImportError:
@@ -45,8 +45,6 @@ class FakeKeyring:
 @pytest.fixture
 def fake_keyring(monkeypatch):
     """Replace the real OS keyring with an in-memory one."""
-    import omero_annotate_ai.omero.simple_connection as sc
-
     keyring = FakeKeyring()
     monkeypatch.setattr(sc, "keyring", keyring, raising=False)
     monkeypatch.setattr(sc, "KEYRING_AVAILABLE", True)
@@ -64,7 +62,7 @@ def manager(tmp_path, monkeypatch):
     home.mkdir()
     monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
 
-    return SimpleOMEROConnection()
+    return sc.SimpleOMEROConnection()
 
 
 class TestKeychain:
@@ -96,8 +94,6 @@ class TestKeychain:
         assert fake_keyring.store == {}
 
     def test_save_reports_failure_without_a_keyring(self, manager, monkeypatch):
-        import omero_annotate_ai.omero.simple_connection as sc
-
         monkeypatch.setattr(sc, "KEYRING_AVAILABLE", False)
 
         assert manager.save_password("omero.example.org", "alice", "s3cret") is False
@@ -175,6 +171,21 @@ class TestEzomeroConfig:
 
         assert os.environ["OMERO_PASSWORD"] == "from-env"
         assert os.environ["OMERO_HOST"] == "omero.example.org"
+
+    def test_unresolvable_home_directory(self, manager, monkeypatch):
+        """Regression: Path.home() raises on Windows with a cleared environment.
+
+        tests/test_omero_integration.py wipes os.environ, which leaves Windows
+        with no USERPROFILE/HOMEPATH to derive a home from. POSIX falls back to
+        the pwd module, so this only ever failed on Windows CI.
+        """
+
+        def no_home():
+            raise RuntimeError("Could not determine home directory.")
+
+        monkeypatch.setattr(Path, "home", staticmethod(no_home))
+
+        assert manager.load_config_files() == {}
 
 
 class TestConnectionHistory:

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -104,7 +104,7 @@ class TestOMEROConnectionWidget:
         widget.port_widget = mock_port_widget
         
         # Simulate connect button click
-        widget._save_and_connect(Mock())
+        widget._connect(Mock())
         
         assert widget.connection == mock_conn
         # Check that create_connection_from_config was called instead of direct connect
@@ -152,7 +152,7 @@ class TestOMEROConnectionWidget:
         widget.password_widget = Mock(value="pass")
         widget.port_widget = Mock(value=4064)
         
-        widget._save_and_connect(Mock())
+        widget._connect(Mock())
         
         assert widget.connection is None
     
@@ -194,10 +194,181 @@ class TestOMEROConnectionWidget:
             }.get(key, default)
             
             widget = OMEROConnectionWidget()
-            
+
             # Check that the widget's fields were populated from config
             # Note: The actual population happens during widget initialization
             # through _load_existing_config method
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not WIDGETS_AVAILABLE, reason="Widget dependencies not available")
+class TestOMEROConnectionWidgetCredentials:
+    """Test how the connection widget handles credentials.
+
+    These tests use the REAL ipywidgets classes and mock only the connection
+    manager. TestOMEROConnectionWidget above mocks ``widgets`` wholesale, which
+    means it cannot catch bugs in how the widgets are wired together.
+    """
+
+    @pytest.fixture
+    def conn_manager(self):
+        """A connection manager with no saved state."""
+        manager = Mock()
+        manager.get_connection_list.return_value = []
+        manager.load_config_files.return_value = {}
+        manager.load_password.return_value = None
+        return manager
+
+    @pytest.fixture
+    def widget(self, conn_manager):
+        with patch(
+            'omero_annotate_ai.widgets.omero_connection_widget.SimpleOMEROConnection',
+            return_value=conn_manager,
+        ):
+            yield OMEROConnectionWidget()
+
+    def test_widget_builds_with_real_ipywidgets(self, widget):
+        """The widget tree is constructed and the input fields are all in it."""
+        assert widget.main_widget is not None
+        assert widget.connection is None
+
+        def flatten(box):
+            for child in getattr(box, "children", ()):
+                yield child
+                yield from flatten(child)
+
+        descendants = list(flatten(widget.main_widget))
+        assert widget.password_widget in descendants
+        assert widget.port_widget in descendants
+        assert widget.host_widget in descendants
+
+    def test_no_show_password_toggle(self, widget):
+        """The plaintext show-password toggle must not come back."""
+        assert not hasattr(widget, "show_password_widget")
+        assert not hasattr(widget, "_toggle_password_visibility")
+
+    def test_password_not_auto_loaded_on_construction(self, conn_manager):
+        """Constructing the widget must not read the keychain."""
+        conn_manager.load_config_files.return_value = {
+            "host": "omero.example.org",
+            "username": "alice",
+            "source": ".env file",
+        }
+
+        with patch(
+            'omero_annotate_ai.widgets.omero_connection_widget.SimpleOMEROConnection',
+            return_value=conn_manager,
+        ):
+            widget = OMEROConnectionWidget()
+
+        conn_manager.load_password.assert_not_called()
+        assert widget.password_widget.value == ""
+        # host/username are still pre-populated, only the secret is withheld
+        assert widget.host_widget.value == "omero.example.org"
+        assert widget.username_widget.value == "alice"
+
+    def test_config_with_missing_host_does_not_crash(self, conn_manager):
+        """A .env with USER_NAME but no HOST yields host=None, which must not raise."""
+        conn_manager.load_config_files.return_value = {
+            "host": None,
+            "username": "alice",
+            "group": None,
+            "source": ".env file",
+        }
+
+        with patch(
+            'omero_annotate_ai.widgets.omero_connection_widget.SimpleOMEROConnection',
+            return_value=conn_manager,
+        ):
+            widget = OMEROConnectionWidget()
+
+        assert widget.host_widget.value == ""
+        assert widget.username_widget.value == "alice"
+
+    def test_get_config_omits_password_by_default(self, widget):
+        """get_config() must not hand back the plaintext password."""
+        widget.host_widget.value = "omero.example.org"
+        widget.username_widget.value = "alice"
+        widget.password_widget.value = "s3cret"
+
+        config = widget.get_config()
+        assert "password" not in config
+        assert config["host"] == "omero.example.org"
+
+        config = widget.get_config(include_password=True)
+        assert config["password"] == "s3cret"
+
+    def test_password_is_not_stripped(self, widget):
+        """Whitespace can be part of a password and must survive verbatim."""
+        widget.password_widget.value = "  pa ss  "
+
+        assert widget._get_widget_config()["password"] == "  pa ss  "
+
+    def test_port_is_included_in_config(self, widget):
+        """The port field is wired into the config the manager receives."""
+        assert widget.port_widget.value == widget.DEFAULT_PORT
+
+        widget.port_widget.value = 6064
+        assert widget._get_widget_config()["port"] == 6064
+
+    def test_connect_reports_failed_keychain_save(self, widget, conn_manager, capsys):
+        """A keychain write that fails must not be reported as a success."""
+        conn_manager.create_connection_from_config.return_value = Mock()
+        conn_manager.save_password.return_value = False
+
+        widget.host_widget.value = "omero.example.org"
+        widget.username_widget.value = "alice"
+        widget.password_widget.value = "s3cret"
+        widget.save_password_widget.value = True
+
+        widget._connect(Mock())
+
+        conn_manager.save_password.assert_called_once()
+        # Outside a live kernel, Output falls through to stdout
+        assert "could NOT be saved" in capsys.readouterr().out
+
+    def test_connect_reports_successful_keychain_save(
+        self, widget, conn_manager, capsys
+    ):
+        conn_manager.create_connection_from_config.return_value = Mock()
+        conn_manager.save_password.return_value = True
+
+        widget.host_widget.value = "omero.example.org"
+        widget.username_widget.value = "alice"
+        widget.password_widget.value = "s3cret"
+        widget.save_password_widget.value = True
+
+        widget._connect(Mock())
+
+        assert "Password saved to keychain" in capsys.readouterr().out
+
+    def test_connect_does_not_save_password_unless_asked(self, widget, conn_manager):
+        conn_manager.create_connection_from_config.return_value = Mock()
+
+        widget.host_widget.value = "omero.example.org"
+        widget.username_widget.value = "alice"
+        widget.password_widget.value = "s3cret"
+        assert widget.save_password_widget.value is False
+
+        widget._connect(Mock())
+
+        conn_manager.save_password.assert_not_called()
+
+    def test_connect_closes_previous_connection(self, widget, conn_manager):
+        """Reconnecting must not leak the previous gateway."""
+        first, second = Mock(), Mock()
+        conn_manager.create_connection_from_config.side_effect = [first, second]
+
+        widget.host_widget.value = "omero.example.org"
+        widget.username_widget.value = "alice"
+        widget.password_widget.value = "s3cret"
+
+        widget._connect(Mock())
+        assert widget.connection is first
+
+        widget._connect(Mock())
+        first.close.assert_called_once()
+        assert widget.connection is second
 
 
 @pytest.mark.skipif(not WIDGETS_AVAILABLE, reason="Widget dependencies not available")
@@ -431,7 +602,7 @@ class TestWidgetIntegration:
             
             with patch('builtins.print'):  # Suppress print output
                 with patch('IPython.display.clear_output'):  # Suppress clear_output
-                    conn_widget._save_and_connect(Mock())
+                    conn_widget._connect(Mock())
             
             # Use connection in workflow widget
             workflow_widget = WorkflowWidget(connection=conn_widget.connection)


### PR DESCRIPTION
## Summary

Security and design review of `src/omero_annotate_ai/widgets/omero_connection_widget.py` and its backend `SimpleOMEROConnection`.

The credential *storage* design was already sound — passwords go to the OS keyring only, never plaintext to disk, and only when the user explicitly ticks "Save password to keychain". What was broken was the code around it: two crash bugs, one silent password-corruption bug, and several paths that spread the password further than it needed to go.

## Crash bugs (both reproduced against `main` before fixing)

- **`AttributeError: 'Dropdown' object has no attribute 'children'`** — `_toggle_password_visibility` indexed `main_widget.children[3]` expecting the connection-fields `VBox`, but index 3 is the dropdown (the VBox is index 5). "Show password" was dead on arrival, and it `.close()`d the real password field first, leaving an orphaned widget the user couldn't type into. **The toggle is removed entirely** — a plaintext `Text` widget also exposes the password in the DOM and in saved notebook state, so it was a security weakness as well as a bug.
- **`AttributeError: 'NoneType' object has no attribute 'strip'`** — any `.env` with `USER_NAME` but no `HOST` killed the widget constructor, because `dict.get(k, "")` returns a stored `None` rather than the default.

## Credential leaks closed

- `load_dotenv` exported **all** of `.env` — including a `PASSWORD=` entry — into `os.environ`, where every subprocess of the kernel could read it. Now uses `dotenv_values`, which doesn't touch the environment.
- `~/.ezomero`'s `[default]` section was copied key-by-key into the config, so a `password=` entry there became `config["password"]`. Now read through a whitelist (host/user/group/port).
- `get_config()` returned the plaintext password; printing it in a notebook writes it into the committed `.ipynb`. Now omitted unless `include_password=True`.
- The widget auto-loaded the keychain password into the field **on construction**. ipywidgets persists widget values into saved notebook state, so this could put a password the user never typed into the `.ipynb`. Now requires an explicit "Load from Keychain" click.

## Correctness

- Passwords were `.strip()`ed before **both** authentication and keychain storage — silently corrupting any password with leading/trailing whitespace.
- The widget printed `🔐 Password saved to keychain` even when `save_password()` returned `False` (e.g. headless Linux with no keyring backend). Password persistence moves out of `create_connection_from_config` and into the widget so the result can be reported honestly.
- A malformed `~/.ezomero` **permanently dropped `OMERO_*` vars from the process environment** — they were deleted and restored inside one `try` block with no `finally`. That whole dance was dead code anyway, since nothing calls `ezomero`.
- Reconnecting leaked the previous `BlitzGateway` and its keep-alive thread.
- No button callback had a `try/except`, unlike every other widget in the package.

## Design

- **Added a real port field.** The backend already accepted a `port` the widget never sent, and `test_connection()` didn't take one at all — so Test Connection and Connect would have used different endpoints. Ports now round-trip through saved connections.
- Dropdown values are stable `host:username` keys rather than mutable dicts rebuilt on every refresh.

## Tests

`main`: 251 unit tests passing → this branch: 267.

- New `tests/test_simple_connection.py` covers the keychain (round-trip, expiry, purge-on-delete) and the `.env` / `.ezomero` leak paths.
- New widget tests use **real ipywidgets** and mock only the connection manager. The existing tests mock the `widgets` module wholesale, which is exactly why the `children[3]` bug survived.
- An autouse `isolated_cwd` fixture runs every test in a temp directory. `OutputConfig.output_directory` defaults to a *relative* `./annotations`, so pipeline auto-saves were overwriting the tracked `annotations/annotation_config_default_annotation_workflow.yaml` on every test run (this happened on a pristine `main` checkout too).

## Deliberately not included

Two hardening options were considered and left out by choice, to avoid changing behaviour beyond the scope of the fix:

- The password field is **not** cleared after a successful connect.
- Unchecking "Secure connection" still sends credentials over an unencrypted channel **without a warning**.

## Verification

- `pytest -m unit` — 267 passed, 1 skipped.
- Built the real widget end-to-end and confirmed: no crash on the partial `.env`, `get_config()` contains no password, and the `.env` password never reaches `os.environ`.
- Both crash bugs were reproduced against `main` first, so the fixes are demonstrated, not assumed.
- Integration tests (`-m omero`, needs a Docker OMERO server) were **not** run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)