### PR TITLE
fix: clean the training folders that are actually written

### DIFF
--- a/src/omero_annotate_ai/processing/training_functions.py
+++ b/src/omero_annotate_ai/processing/training_functions.py
@@ -97,6 +97,45 @@ def _create_training_directories(
     return created_dirs
 
 
+def _get_dataset_folder_names(uses_separate_channels: bool = False) -> List[str]:
+    """
+    Get the folder names written by _prepare_dataset_from_table.
+
+    These differ from _get_standard_folder_structure(): _prepare_dataset_from_table
+    derives folder names from its ``subset_type`` argument ("training", "val",
+    "training_label", "val_label"), producing ``training_input`` rather than
+    ``train_input``.
+
+    Args:
+        uses_separate_channels: Whether label_input folders are written
+
+    Returns:
+        List of folder names, relative to the output directory
+    """
+    folders = ["training_input", "training_label", "val_input", "val_label"]
+
+    if uses_separate_channels:
+        folders += ["training_label_input", "val_label_input"]
+
+    return folders
+
+
+def _clean_dataset_directories(
+    output_dir: Path, uses_separate_channels: bool = False
+) -> None:
+    """
+    Remove the dataset folders that _prepare_dataset_from_table will repopulate.
+
+    Args:
+        output_dir: Base output directory
+        uses_separate_channels: Whether label_input folders are written
+    """
+    for folder_name in _get_dataset_folder_names(uses_separate_channels):
+        folder_path = output_dir / folder_name
+        if folder_path.exists():
+            shutil.rmtree(folder_path)
+
+
 def _build_standard_result(
     base_dir: Path, created_dirs: Dict[str, Path], stats: Dict[str, Any], **extra_fields
 ) -> Dict[str, Any]:
@@ -273,13 +312,10 @@ def prepare_training_data_from_table(
     # Determine the effective training channel to use
     effective_train_channel = training_channels[0] if training_channels else None
 
-    # Create standard directory structure
-    created_dirs = _create_training_directories(
-        output_dir=output_dir,
-        uses_separate_channels=uses_separate_channels,
-        include_test=False,  # Table function doesn't support test category
-        clean_existing=clean_existing,
-    )
+    # Clean the folders _prepare_dataset_from_table writes to; it creates them itself
+    if clean_existing:
+        _clean_dataset_directories(output_dir, uses_separate_channels)
+    created_dirs: Dict[str, Path] = {}
 
     # Split data based on existing 'train'/'validate' columns or automatic split
     if "train" in table.columns and "validate" in table.columns:
@@ -562,13 +598,10 @@ def prepare_training_data_from_config(
             f"Using separate channels: label={label_channel}, training={training_channels}"
         )
 
-    # Create standard directory structure
-    created_dirs = _create_training_directories(
-        output_dir=output_dir,
-        uses_separate_channels=uses_separate_channels,
-        include_test=False,  # Config function doesn't support test category
-        clean_existing=clean_existing,
-    )
+    # Clean the folders _prepare_dataset_from_table writes to; it creates them itself
+    if clean_existing:
+        _clean_dataset_directories(output_dir, uses_separate_channels)
+    created_dirs: Dict[str, Path] = {}
 
     # Split data based on 'train'/'validate' columns
     if "train" in df.columns and "validate" in df.columns:

--- a/tests/test_training_functions.py
+++ b/tests/test_training_functions.py
@@ -13,6 +13,8 @@ from omero_annotate_ai.processing.training_functions import (
     _prepare_dataset_from_table,
     reorganize_local_data_for_training,
     _create_file_link_or_copy,
+    _get_dataset_folder_names,
+    _clean_dataset_directories,
 )
 from omero_annotate_ai.core.annotation_config import AnnotationConfig, ImageAnnotation
 
@@ -1323,3 +1325,67 @@ class TestExternalClassificationWorkflow:
         assert config2.spatial_coverage.training_channels == [0]
         assert config2.annotation_methodology.annotation_type == "classification"
         assert config2.annotation_methodology.annotation_method == "automatic"
+
+
+@pytest.mark.unit
+class TestDatasetDirectoryCleanup:
+    """Cleaning of the folders that _prepare_dataset_from_table writes to."""
+
+    def test_folder_names_single_channel(self):
+        """Single-channel runs clean the four dataset folders."""
+        assert _get_dataset_folder_names() == [
+            "training_input",
+            "training_label",
+            "val_input",
+            "val_label",
+        ]
+
+    def test_folder_names_separate_channels(self):
+        """Separate-channel runs also clean the label_input folders."""
+        folders = _get_dataset_folder_names(uses_separate_channels=True)
+
+        assert "training_label_input" in folders
+        assert "val_label_input" in folders
+
+    def test_clean_removes_stale_training_data(self, tmp_path):
+        """Stale training images must not survive a clean_existing run.
+
+        Cleanup used to target train_input/, a folder nothing writes to, so images
+        from an earlier run lingered in training_input/ and leaked into the next one.
+        """
+        stale = tmp_path / "training_input" / "old.tif"
+        stale.parent.mkdir(parents=True)
+        stale.write_bytes(b"stale")
+
+        _clean_dataset_directories(tmp_path)
+
+        assert not stale.exists()
+
+    def test_clean_removes_stale_label_input_data(self, tmp_path):
+        """Separate-channel label images are cleaned too."""
+        stale = tmp_path / "training_label_input" / "old.tif"
+        stale.parent.mkdir(parents=True)
+        stale.write_bytes(b"stale")
+
+        _clean_dataset_directories(tmp_path, uses_separate_channels=True)
+
+        assert not stale.exists()
+
+    def test_clean_is_safe_when_directories_absent(self, tmp_path):
+        """A first run has nothing to clean and must not raise."""
+        _clean_dataset_directories(tmp_path, uses_separate_channels=True)
+
+    def test_cleaned_names_match_prepare_dataset_output(self):
+        """Every folder _prepare_dataset_from_table writes to must be cleaned.
+
+        _prepare_dataset_from_table derives its folders from subset_type, as
+        f"{subset_type}_input" and f"{subset_type}_label". If a caller adds a
+        subset_type, this pins the cleanup list to it.
+        """
+        cleaned = _get_dataset_folder_names(uses_separate_channels=True)
+
+        for subset_type in ("training", "val", "training_label", "val_label"):
+            assert f"{subset_type}_input" in cleaned
+
+        for subset_type in ("training", "val"):
+            assert f"{subset_type}_label" in cleaned


### PR DESCRIPTION
## The bug

`prepare_training_data_from_table()` and `prepare_training_data_from_config()` cleaned the wrong directories.

They called `_create_training_directories()`, which names folders via `_get_standard_folder_structure()`. But the data is written by `_prepare_dataset_from_table()`, which derives folder names from its `subset_type` argument. The two never agreed:

| | folders |
|---|---|
| Cleaned by `clean_existing=True` | `train_input`, `train_label`, `train_label_input`, `val_input`, `val_label`, `val_label_input` |
| Actually written | **`training_input`**, **`training_label`**, **`training_label_input`**, `val_input`, `val_label`, `val_label_input` |

So `clean_existing=True`:

1. **Left stale training data in place.** `training_input/`, `training_label/` and `training_label_input/` were never cleaned. Images from a previous run persisted — change the train/val split and re-run, and old training images silently mix into the new set. Only `val_input`/`val_label` overlapped by coincidence and were cleaned correctly.
2. **Created three phantom empty folders** (`train_input/`, `train_label/`, `train_label_input/`) on every run.

## The fix

Clean the folder names `_prepare_dataset_from_table()` actually produces, via a shared `_clean_dataset_directories()` helper, and let that function create the folders it owns (it already does, with `mkdir`).

`_get_standard_folder_structure()` and `_create_training_directories()` are **unchanged**. They still back `reorganize_local_data_for_training()`, which uses the `train_*` layout consistently and has tests pinning those names.

## Compatibility

The result dict keeps every key consumers read. `setup_training()` (in `training_utils.py`) requires `training_input`, `training_label`, `val_input`, `val_label` — all still present, all still pointing at the same paths. The only keys dropped are the redundant `validation_input` / `validation_label` / `validation_label_input` duplicates, which nothing reads.

## Tests

New `TestDatasetDirectoryCleanup` (6 tests), including a regression test that stale files in `training_input/` do not survive a clean run, and one that pins the cleanup list to every `subset_type` used by callers.

Full suite: **316 passed, 5 skipped**.

## Reviewer note: `training_input/` is an overloaded name

Worth a second pair of eyes. `training_input/` means two different things depending on phase:

- **Annotation phase** (`AnnotationPipeline._setup_directories`, separate-channel mode): `training_input/` holds the *source* training-channel images (e.g. brightfield) pulled from OMERO.
- **Training phase** (this function): `training_input/` holds the *training split* of the prepared dataset.

If a caller passes `output_dir` equal to the annotation output directory, `clean_existing=True` will now `rmtree` the annotation phase's `training_input/` — i.e. delete source images. Previously it cleaned the unused `train_input/`, so it did not delete them (it would instead have written the downloaded set on top of them, which is also wrong, just differently).

No current caller does this — every notebook passes a fresh or timestamped subdirectory — so this is not a live regression. But the overlap is undocumented and the naming makes it easy to hit. A follow-up should either give the two phases distinct names or guard against `output_dir` overlapping the annotation directory.

## Known, not fixed here

- `_prepare_dataset_from_table(subset_type="training_label")` also creates an unused `training_label_label/` folder (its label dir is discarded by the caller). Cosmetic; left alone to keep this diff scoped.
- `reorganize_local_data_for_training()` returns `validation_input`/`validation_label` but not `val_input`/`val_label`, so its result cannot be fed to `setup_training()` — it would raise `ValueError: training_result missing required keys`. Latent: no caller currently pipes reorganize's output into `setup_training` (all notebooks go via `prepare_training_data_from_table`). Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)