### PR TITLE
refactor: unify the annotation and training folder layouts

### DIFF
--- a/src/omero_annotate_ai/processing/training_functions.py
+++ b/src/omero_annotate_ai/processing/training_functions.py
@@ -427,11 +427,13 @@ def _fetch_plane(conn, row, channel: int, logger=None) -> np.ndarray:
                         f"  Returned array shape (before extraction): {img_slice.shape}"
                     )
 
-                # The result will be 5D, extract just the 2D slice
-                img_slice = img_slice[
-                    :, :, 0, 0, 0
-                ]  # Extract the single z-slice
-                img_slice = np.swapaxes(img_slice, 0, 1)
+                # The result will be 5D, extract just the 2D slice.
+                # ezomero hands back XYZCT, so x is axis 0; swap to (Y, X) like every
+                # other branch does. Omitting this swap here transposed volumetric
+                # patches against their labels.
+                if len(img_slice.shape) == 5:
+                    img_slice = img_slice[:, :, 0, 0, 0]
+                    img_slice = np.swapaxes(img_slice, 0, 1)
                 if logger:
                     logger.debug(f"Extracted slice shape: {img_slice.shape}")
                 else:

--- a/tests/test_training_functions.py
+++ b/tests/test_training_functions.py
@@ -829,6 +829,11 @@ class TestFetchPlane3D:
         assert img[0].max() < 255
 
     def test_volumetric_patch_is_returned_as_z_height_width(self, fake_ezomero):
+        """The 3D-patch branch used to skip np.swapaxes, so it alone returned (Z, X, Y).
+
+        A 3-wide by 2-high patch came back as (Z, 3, 2) instead of (Z, 2, 3),
+        transposing every volumetric patch against its label.
+        """
         img = tf._fetch_plane(
             None,
             _plane_row(is_volumetric=True, z_slice="all", is_patch=True,
@@ -836,6 +841,32 @@ class TestFetchPlane3D:
             channel=0,
         )
         assert img.shape == (PLANE_Z, 2, 3)  # (Z, height, width)
+
+    def test_volumetric_patch_content_is_not_transposed(self, fake_ezomero):
+        """Shape alone would still pass on a square patch; pin the content too."""
+        img = tf._fetch_plane(
+            None,
+            _plane_row(is_volumetric=True, z_slice="all", is_patch=True,
+                patch_x=2, patch_y=1, patch_width=3, patch_height=3),
+            channel=0,
+        )
+        # Voxel value is x + 10y + 100z, so a step along +y outweighs a step along +x.
+        # In (Z, Y, X) the far-y corner is therefore brighter than the far-x corner;
+        # a transpose swaps exactly these two probes.
+        assert img[0, -1, 0] > img[0, 0, -1]
+
+    def test_all_branches_agree_on_orientation(self, fake_ezomero):
+        """A 2D patch and the same patch fetched volumetrically must not disagree."""
+        patch_kwargs = dict(is_patch=True, patch_x=2, patch_y=1,
+                            patch_width=3, patch_height=2)
+
+        flat = tf._fetch_plane(None, _plane_row(**patch_kwargs), channel=0)
+        volumetric = tf._fetch_plane(
+            None, _plane_row(is_volumetric=True, z_slice=0, **patch_kwargs), channel=0
+        )
+
+        assert flat.shape == volumetric[0].shape
+        np.testing.assert_array_equal(flat, volumetric[0])
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-13-folder-layout-unification-design.md`.

## Why

The package had three folder layouts, and the same name meant different things in different phases.

| Phase | Folders (before) |
|---|---|
| Annotation | `input/` or `label_input/` + `training_input/`, `output/` |
| OMERO → training | `training_input/`, `training_label/`, `val_input/`, `val_label/` |
| Local → training | `train_input/`, `train_label/`, `val_input/`, `val_label/` |

`training_input/` meant the *source brightfield channel* in the annotation phase and the *training split* in the training phase. Since `reorganize_for_training()` defaulted its output to the annotation directory, a `clean_existing=True` run could delete the user's source images.

## The bug this fixes

`_prepare_dataset_from_table` named files by **loop index** (`input_{n:05d}.tif`) and wrote the image **before** downloading its label. On a missing or failed label it hit `continue`, leaving an orphan image.

micro-SAM pairs `raw_paths` to `label_paths` by sorted filename. So **one missing label silently shifted every subsequent image/label pair by one** — training ran on mismatched data with no error. Same class as the glob-ordering bug fixed in #42, still live on the OMERO path.

Files are now named by `annotation_id`, and a record whose image or label is missing is dropped whole. `TestPrepareFromTableRecords::test_a_missing_label_does_not_shift_later_pairs` fails on the old code.

A second latent bug also dies: `reorganize_local_data_for_training()` returned `validation_input`/`validation_label` while `setup_training()` required `val_input`/`val_label`, so piping one into the other raised `ValueError`. Both producers now emit the same keys, verified end to end.

## The layout

```
ANNOTATION ROOT                    TRAINING ROOT (sibling, separate)
  annotation_input/   <- you draw    train_input/   <- model trains on
  model_input/        <- model in    train_label/
  annotation_output/  <- masks       val_input/
  sam_embeddings/                    val_label/
```

`processing/training_layout.py` now owns the layout. Both producers resolve inputs into `AnnotationRecord`s and hand them to `write_training_layout()`, so folder naming, cleaning, splitting and stats exist in exactly one place. `prepare_training_data*` raises `ValueError` if the training directory is inside the annotation directory.

`file_mode` (copy/move/symlink) applies only to the offline producer — the OMERO producer fetches planes, so there is nothing to link. The symlink→copy fallback for Windows without Developer Mode is preserved and tested.

`layout="cellpose"` (flat `{id}.tif` + `{id}_masks.tif`) is specified and raises `NotImplementedError`. Adding it later is one branch in `write_training_layout`, with no caller changes.

## OMERO identifiers

Renamed to match the disk layout: `label_input_id` → `annotation_input_id`, namespace → `.../annotate/annotation_input`, `upload_label_input_image()` → `upload_annotation_input_image()`.

This is safe because neither persisted identifier is used to *find* data: the namespace is write-only (nothing queries by it), and annotations are reached via the id in the tracking table. The table column *does* live on users' OMERO servers and cannot be migrated, so `from_dataframe()` accepts either name. **That read-side fallback is the only backwards-compatibility shim in this PR**, and it is tested.

## Deletions

- `prepare_training_data_from_config()` (~210 lines, no callers, no tests, not exported)
- `_get_standard_folder_structure` / `_create_training_directories` / `_get_dataset_folder_names` / `_clean_dataset_directories`
- 179 commented-out test lines. They were commented out because the OMERO-download path could not be mocked; the record split made it injectable, so they come back as real tests rather than being merely deleted.

## Tests

**332 passed, 5 skipped.** `pixi.lock` unchanged (no dependency changes).

Note: `CLAUDE.md` documents the old layout but is gitignored, so it is not in this diff — updated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)