### PR TITLE
feat: ISCC content provenance for published annotation datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,6 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
-CLAUDE.md
 TODO_LIST.md
 TODO_LIST.md
 TODO_LIST.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,607 @@
+# OMERO Annotate AI - Development Guide
+
+## Development Environment
+
+### Before Creating a PR
+
+Always update `pixi.lock` before pushing — CI will fail if it is out of date:
+
+```bash
+pixi install
+```
+
+Then stage and commit `pixi.lock` together with the other changes.
+
+### Running Tests
+
+To run the test suite, use the dev environment:
+
+```bash
+pixi run -e dev pytest tests/ -v
+```
+
+For a specific test file:
+```bash
+pixi run -e dev pytest tests/test_config.py -v
+```
+
+### Test Organization Guidelines
+
+Tests should be organized alongside the source code structure. **Do not create separate test files for individual features** - instead, add tests to existing test files that correspond to the module being tested.
+
+#### Test File Mapping
+
+| Source Module | Test File | Description |
+|---------------|-----------|-------------|
+| `core/annotation_config.py` | `tests/test_config.py` | Configuration classes, schema validation, serialization |
+| `core/annotation_pipeline.py` | `tests/test_pipeline.py` | Pipeline methods, workflow logic |
+| `core/annotation_pipeline.py` | `tests/test_well_filtering.py` | Container/image retrieval, filtering |
+| `omero/omero_functions.py` | `tests/test_omero_functions.py` | OMERO API functions, table management |
+| `omero/omero_utils.py` | `tests/test_omero_functions.py` | OMERO utility functions |
+| `processing/training_functions.py` | `tests/test_training_functions.py` | Training data preparation |
+| `widgets/` | `tests/test_widgets.py` | Widget classes and UI components |
+
+#### Test Class Organization
+
+Within each test file, group related tests into classes:
+
+```python
+@pytest.mark.unit
+class TestFeatureName:
+    """Test description."""
+
+    def test_specific_behavior(self):
+        """Test that specific behavior works correctly."""
+        ...
+```
+
+#### Test Markers
+
+- `@pytest.mark.unit` - Fast unit tests with mocked dependencies
+- `@pytest.mark.integration` - Integration tests with mocked OMERO connection
+- `@pytest.mark.slow` - Tests that take longer to run
+
+#### Adding Tests for New Features
+
+1. Identify the source module your feature modifies
+2. Find the corresponding test file from the mapping above
+3. Add a new test class or add tests to an existing relevant class
+4. Use consistent naming: `TestFeatureName` for classes, `test_specific_behavior` for methods
+
+---
+
+## Notebook Structure
+
+Notebooks live in `notebooks/` with three subdirectories:
+
+- **`marimo/`** — Reactive marimo notebooks (`.py` files, preferred for new notebooks)
+  - `omero-annotate-ai-annotation.py` — micro-SAM annotation (gold standard/reference pattern)
+  - `omero-annotate-ai-cellpose.py` — CellPose annotation
+  - `omero-annotate-ai-from-yaml.py` — Run from saved YAML config
+  - `omero-training-microsam.py` — micro-SAM training
+  - `omero-idr-demo.py` — Full demo on public IDR data (read-only mode)
+- **`jupyter/`** — Classic Jupyter notebooks (`annotation/`, `training/`, `inference/`, `other/`)
+- **`dev/`** — Developer notebooks (autoreload helpers, not for end users)
+
+When creating new notebooks, prefer marimo. Follow the pattern in `omero-annotate-ai-annotation.py`:
+- Connection via `SimpleOMEROConnection.create_connection_from_config()`
+- Config via `create_default_config()` + field assignment
+- `mo.ui.run_button` + `mo.stop()` for action triggers
+- `build_config()` helper function to map UI values → `AnnotationConfig`
+
+IDR connection: `ws://idr.openmicroscopy.org/omero-ws`, user `public`, password `public`, `secure=False`, `read_only_mode=True`.
+
+---
+
+## Marimo Notebook Assistant
+
+When creating or editing marimo notebooks for this project, follow these guidelines.
+
+### Marimo Fundamentals
+
+Marimo is a reactive notebook that differs from traditional notebooks:
+
+- Cells execute automatically when their dependencies change
+- Variables cannot be redeclared across cells
+- The notebook forms a directed acyclic graph (DAG)
+- The last expression in a cell is automatically displayed
+- UI elements are reactive and update the notebook automatically
+
+### Editing Marimo Notebooks
+
+If you make edits to the notebook, only edit the contents inside the function decorator with `@app.cell`.
+Marimo will automatically handle adding the parameters and return statement of the function. For example,
+for each edit, just return:
+
+```python
+@app.cell
+def _():
+    return
+```
+
+### Code Requirements
+
+1. All code must be complete and runnable
+2. Follow consistent coding style throughout
+3. Include descriptive variable names and helpful comments
+4. Import all modules in the first cell, always including `import marimo as mo`
+5. Never redeclare variables across cells
+6. Ensure no cycles in notebook dependency graph
+7. The last expression in a cell is automatically displayed
+8. Don't include comments in markdown cells
+9. Don't include comments in SQL cells
+10. Never define anything using `global`
+
+### Reactivity
+
+- When a variable changes, all cells that use that variable automatically re-execute
+- UI elements trigger updates when their values change without explicit callbacks
+- UI element values are accessed through `.value` attribute
+- You cannot access a UI element's value in the same cell where it's defined
+- Cells prefixed with an underscore (e.g. `_my_var`) are local to the cell and cannot be accessed by other cells
+
+### Best Practices
+
+**Data Handling:**
+- Use polars for data manipulation
+- Implement proper data validation
+- Handle missing values appropriately
+- A variable in the last expression of a cell is automatically displayed as a table
+
+**Visualization:**
+- For matplotlib: use `plt.gca()` as the last expression instead of `plt.show()`
+- For plotly: return the figure object directly
+- For altair: return the chart object directly. Add tooltips where appropriate.
+- Include proper labels, titles, and color schemes
+
+**UI Elements:**
+- Access UI element values with `.value` attribute (e.g., `slider.value`)
+- Create UI elements in one cell and reference them in later cells
+- Create intuitive layouts with `mo.hstack()`, `mo.vstack()`, and `mo.tabs()`
+- Prefer reactive updates over callbacks
+
+### Available UI Elements
+
+- `mo.ui.altair_chart(altair_chart)`
+- `mo.ui.button(value=None, kind='primary')`
+- `mo.ui.run_button(label=None, tooltip=None, kind='primary')`
+- `mo.ui.checkbox(label='', value=False)`
+- `mo.ui.date(value=None, label=None, full_width=False)`
+- `mo.ui.dropdown(options, value=None, label=None, full_width=False)`
+- `mo.ui.file(label='', multiple=False, full_width=False)`
+- `mo.ui.number(value=None, label=None, full_width=False)`
+- `mo.ui.radio(options, value=None, label=None, full_width=False)`
+- `mo.ui.slider(start, stop, value=None, label=None, full_width=False, step=None)`
+- `mo.ui.range_slider(start, stop, value=None, label=None, full_width=False, step=None)`
+- `mo.ui.table(data, columns=None, on_select=None, sortable=True, filterable=True)`
+- `mo.ui.text(value='', label=None, full_width=False)`
+- `mo.ui.text_area(value='', label=None, full_width=False)`
+- `mo.ui.data_explorer(df)`
+- `mo.ui.dataframe(df)`
+- `mo.ui.plotly(plotly_figure)`
+- `mo.ui.tabs(elements: dict[str, mo.ui.Element])`
+- `mo.ui.form(element: mo.ui.Element, label='', bordered=True)`
+
+### Layout and Utility Functions
+
+- `mo.md(text)` - display markdown
+- `mo.stop(predicate, output=None)` - stop execution conditionally
+- `mo.output.append(value)` - append to the output
+- `mo.output.replace(value)` - replace the output
+- `mo.Html(html)` - display HTML
+- `mo.image(image)` - display an image
+- `mo.hstack(elements)` - stack elements horizontally
+- `mo.vstack(elements)` - stack elements vertically
+- `mo.tabs(elements)` - create a tabbed interface
+
+### Troubleshooting
+
+- **Circular dependencies**: Reorganize code to remove cycles in the dependency graph
+- **UI element value access**: Move access to a separate cell from definition
+- **Visualization not showing**: Ensure the visualization object is the last expression
+
+After generating a notebook, run `marimo check --fix` to catch and automatically resolve common formatting issues.
+
+---
+
+# Well Filtering Feature Implementation
+
+**Date**: 2025-12-03
+**Feature**: Filter datasets based on key-value pair metadata attached to wells in plates
+
+## Summary
+
+Implemented well filtering functionality to allow filtering plate datasets based on map annotation key-value pairs attached to individual wells (e.g., cellline: U2OS, HeLa).
+
+## Changes Made
+
+### 1. Schema Updates ([annotation_config.py:270-280](src/omero_annotate_ai/core/annotation_config.py#L270-L280))
+
+Added two new fields to `OMEROConfig`:
+- `well_filters`: Optional Dict[str, List[str]] - Filter criteria with AND logic
+- `well_filter_mode`: Literal["include", "exclude"] - Include or exclude matching wells
+
+### 2. Pipeline Methods ([annotation_pipeline.py:836-938](src/omero_annotate_ai/core/annotation_pipeline.py#L836-L938))
+
+Added three new methods to `AnnotationPipeline`:
+- `_get_well_map_annotations(well_id)`: Retrieves map annotations from a well as dict
+- `_check_well_filter(well_kv_pairs, filters)`: Checks if well matches filter criteria (AND logic)
+- Updated `get_image_ids_from_container()`: Applies well filtering when container_type is "plate"
+
+### 3. Tests ([tests/test_well_filtering.py](tests/test_well_filtering.py))
+
+Created comprehensive test suite with 11 tests:
+- Unit tests for filter matching logic
+- Tests for map annotation retrieval
+- Tests for include/exclude modes
+- Integration tests for full filtering workflow
+
+## Usage
+
+### In Notebook
+```python
+config = workflow_widget.get_config()
+config.omero.well_filters = {
+    "cellline": ["U2OS", "HeLa"],
+    "treatment": ["Control"]
+}
+config.omero.well_filter_mode = "include"
+pipeline = create_pipeline(config, conn)
+```
+
+### In YAML
+```yaml
+omero:
+  container_type: plate
+  container_id: 1
+  well_filters:
+    cellline: ["U2OS", "HeLa"]
+    treatment: ["Control"]
+  well_filter_mode: include
+```
+
+## Implementation Details
+
+- **Filter Logic**: AND logic - all conditions must be met
+- **Metadata Location**: Map annotations on Well objects (navigated via Image → WellSample → Well)
+- **Filter Modes**:
+  - `include`: Only process wells matching ALL criteria
+  - `exclude`: Process all wells EXCEPT those matching criteria
+- **No Filtering**: If `well_filters` is None or empty, all wells are processed
+
+## Test Results
+
+All 99 tests pass (93 passed, 6 skipped):
+- 11 new well filtering tests
+- All existing tests remain passing
+- No breaking changes
+
+## Files Modified
+
+1. `src/omero_annotate_ai/core/annotation_config.py` - Added schema fields
+2. `src/omero_annotate_ai/core/annotation_pipeline.py` - Added filtering logic
+3. `tests/test_well_filtering.py` - New test file (auto-discovered by pytest)
+
+---
+
+# Multi-Container Support Feature Implementation
+
+**Date**: 2025-01-15
+**Feature**: Support multiple OMERO containers of the same type with shared table attachment
+
+## Summary
+
+Extended the annotation pipeline to support multiple container IDs of the same type (e.g., multiple plates or datasets), with the tracking table attached to ALL source containers via OMERO AnnotationLink objects.
+
+## Changes Made
+
+### 1. Schema Updates ([annotation_config.py:417-480](src/omero_annotate_ai/core/annotation_config.py#L417-L480))
+
+Added new field and helper methods to `OMEROConfig`:
+- `container_ids`: Optional List[int] - List of container IDs (takes precedence over container_id)
+- `get_all_container_ids()`: Returns all container IDs with precedence logic
+- `get_primary_container_id()`: Returns the first container ID
+- `is_multi_container()`: Checks if multiple containers are configured
+
+### 2. Pipeline Methods ([annotation_pipeline.py](src/omero_annotate_ai/core/annotation_pipeline.py))
+
+Added/updated methods in `AnnotationPipeline`:
+- `_get_image_ids_from_plate(container_id)`: Extracts plate-specific logic for reuse
+- `_get_image_ids_from_single_container(container_type, container_id)`: Gets images from one container
+- Updated `get_image_ids_from_container()`: Iterates over all containers, removes duplicates
+- Updated `_get_table_title()`: Reflects multi-container in auto-generated titles
+
+### 3. OMERO Functions ([omero_functions.py](src/omero_annotate_ai/omero/omero_functions.py))
+
+Added new function and updated existing:
+- `link_table_to_containers(conn, table_id, container_type, container_ids)`: Links FileAnnotation to multiple containers using AnnotationLink objects
+- Updated `create_or_replace_tracking_table()`: Accepts `container_ids` list, links to all containers
+- Updated `sync_config_to_omero_table()`: Supports multi-container parameter
+
+### 4. Tests
+
+Tests added to existing test files:
+- `tests/test_config.py`: TestOMEROConfigMultiContainer class (12 tests)
+- `tests/test_well_filtering.py`: TestMultiContainerImageRetrieval, TestMultiContainerTableTitle classes (8 tests)
+- `tests/test_omero_functions.py`: TestLinkTableToContainers, TestCreateOrReplaceTrackingTableMultiContainer classes (5 tests)
+
+## Usage
+
+### In Notebook
+```python
+config = workflow_widget.get_config()
+config.omero.container_ids = [123, 456, 789]  # Multiple plates/datasets
+config.omero.container_type = "plate"
+# Well filters apply to ALL plates
+config.omero.well_filters = {"cellline": ["U2OS"]}
+pipeline = create_pipeline(config, conn)
+```
+
+### In YAML
+```yaml
+omero:
+  container_type: plate
+  # Multiple containers (new):
+  container_ids: [123, 456, 789]
+
+  # Single container (legacy, still works):
+  # container_id: 123
+
+  # Well filtering applies to ALL plates
+  well_filters:
+    cellline: ["U2OS", "HeLa"]
+  well_filter_mode: include
+```
+
+## Implementation Details
+
+- **Precedence**: `container_ids` takes precedence over `container_id` when both are set
+- **Backward Compatibility**: Single `container_id` configs continue to work unchanged
+- **Table Attachment**: Uses OMERO AnnotationLink objects (e.g., PlateAnnotationLinkI) to attach the same FileAnnotation to multiple containers
+- **Duplicate Removal**: Images appearing in multiple containers are deduplicated (first occurrence wins)
+- **Well Filtering**: Filters apply globally to all plate containers
+
+## OMERO API for Multi-Container Table Linking
+
+The `link_table_to_containers()` function uses OMERO's AnnotationLink classes:
+```python
+import omero.model as model
+
+link_classes = {
+    'dataset': (model.DatasetAnnotationLinkI, model.DatasetI),
+    'plate': (model.PlateAnnotationLinkI, model.PlateI),
+    'project': (model.ProjectAnnotationLinkI, model.ProjectI),
+    'screen': (model.ScreenAnnotationLinkI, model.ScreenI),
+}
+
+# table_id is the FileAnnotation ID
+file_ann = conn.getObject("FileAnnotation", table_id)
+LinkClass, ContainerClass = link_classes[container_type]
+
+for container_id in container_ids:
+    link = LinkClass()
+    link.setParent(ContainerClass(container_id, False))
+    link.setChild(file_ann._obj)
+    update_service.saveAndReturnObject(link)
+```
+
+## Files Modified
+
+1. `src/omero_annotate_ai/core/annotation_config.py` - Added `container_ids` field and helper methods
+2. `src/omero_annotate_ai/core/annotation_pipeline.py` - Multi-container image retrieval and table title
+3. `src/omero_annotate_ai/omero/omero_functions.py` - Added `link_table_to_containers()`, updated table creation
+4. `tests/test_config.py` - Added TestOMEROConfigMultiContainer tests
+5. `tests/test_well_filtering.py` - Added multi-container pipeline tests
+6. `tests/test_omero_functions.py` - Added multi-container OMERO function tests
+
+---
+
+# Folder Layout
+
+**Date**: 2026-07-13
+
+## Annotation phase
+
+`AnnotationPipeline`, under `config.output.output_directory`:
+
+- `annotation_input/{id}.tif` — the channel you annotate (e.g. fluorescence)
+- `model_input/{id}.tif` — the channel the model consumes (e.g. brightfield); separate-channel workflows only
+- `annotation_output/{id}_mask.tif` — the mask you produced
+- `sam_embeddings/` — micro-SAM only
+
+Single-channel workflows have no `model_input/`; `annotation_input/` serves both roles.
+
+## Training phase
+
+In a **separate** directory, defaulting to the sibling `<annotation_dir>_training/`:
+
+- `train_input/{id}.tif`, `train_label/{id}.tif`
+- `val_input/{id}.tif`, `val_label/{id}.tif`
+- `test_*` when `include_test=True`
+- `train_annotation_input/`, `val_annotation_input/` for separate-channel workflows
+
+The training directory must NOT be inside the annotation directory — `prepare_training_data*`
+raises `ValueError` if it is, because cleaning the training layout there would delete the
+source images.
+
+## Rules that hold everywhere
+
+Files are named by `annotation_id`, so an image and its label always pair by name. A record
+whose image or label is missing is dropped whole — never written as an orphan. (Consumers such
+as micro-SAM pair `raw_paths` to `label_paths` by sorted filename, so a single orphan silently
+shifts every subsequent pair.)
+
+`processing/training_layout.py` owns the layout. Both producers
+(`prepare_training_data_from_table`, `reorganize_local_data_for_training`) resolve their inputs
+into `AnnotationRecord`s and hand them to `write_training_layout()`. `file_mode`
+(copy/move/symlink) applies only to the offline producer — the OMERO producer fetches planes,
+so there is no file to link. Symlinks fall back to a copy where unavailable (Windows without
+Developer Mode). `layout="cellpose"` is specified but raises `NotImplementedError`.
+
+Both producers return `train_input` / `train_label` / `val_input` / `val_label`, which is what
+`setup_training()` requires.
+
+## OMERO identifiers
+
+Disk and OMERO names match: `annotation_input_id` (table column),
+`openmicroscopy.org/omero/annotate/annotation_input` (namespace),
+`upload_annotation_input_image()`. Tables written before the rename carry `label_input_id`;
+`from_dataframe()` accepts either name, since those tables live on users' servers and cannot be
+migrated. That read-side fallback is the only backwards-compatibility shim in the codebase.
+
+---
+
+When writing an anywidget use vanilla javascript in `_esm` and do not forget about `_css`. The css should look bespoke in light mode and dark mode. Keep the css small unless explicitly asked to go the extra mile. When you display the widget it must be wrapped via `widget = mo.ui.anywidget(OriginalAnywidget())`.
+
+<example title="Example anywidget implementation">
+import anywidget
+import traitlets
+
+
+class CounterWidget(anywidget.AnyWidget):
+    _esm = """
+    // Define the main render function
+    function render({ model, el }) {
+      let count = () => model.get("number");
+      let btn = document.createElement("button");
+      btn.innerHTML = `count is ${count()}`;
+      btn.addEventListener("click", () => {
+        model.set("number", count() + 1);
+        model.save_changes();
+      });
+      model.on("change:number", () => {
+        btn.innerHTML = `count is ${count()}`;
+      });
+      el.appendChild(btn);
+    }
+    // Important! We must export at the bottom here!
+    export default { render };
+    """
+    _css = """button{
+      font-size: 14px;
+    }"""
+    number = traitlets.Int(0).tag(sync=True)
+
+widget = mo.ui.anywidget(CounterWidget())
+widget
+
+# Grabbing the widget from another cell, `.value` is a dictionary.
+print(widget.value["number"])
+</example>
+
+When sharing the anywidget, keep the example minimal. No need to combine it with marimo ui elements unless explicitly stated to do so.
+
+---
+
+# Napari Plugin
+
+**Branch**: `feat/napari-plugin`
+**Worktree**: `../omero_annotate_ai.worktrees/napari-plugin`
+
+Plugin lives in `src/omero_annotate_ai/napari_plugin/`:
+- `napari.yaml` — npe2 manifest (points directly at `OMEROAnnotateWidget`)
+- `_widget.py` — `OMEROAnnotateWidget(QWidget)`: 3 tabs (Connection / Configure / Run)
+- `_worker.py` — `AnnotationWorker(QRunnable)`: OMERO setup stages run in background thread; emits `ready_to_annotate` signal so `run_microsam_annotation()` executes on the main thread (required for Qt/GL)
+
+Key threading rule: `image_series_annotator` creates napari layers and **must run on the main thread**. The worker only handles OMERO I/O (`initialize_workflow`, `define_annotation_schema`, `create_tracking_table`).
+
+`annotation_pipeline.py` has a `_napari_viewer` attribute (default `None`). When set by the plugin, `image_series_annotator` reuses the existing viewer and `napari.run()` is skipped. Notebook behaviour is unchanged.
+
+npe2 entry point requires the annotation to be a live type (not a string): `napari_viewer: napari.Viewer` in `__init__`, no `from __future__ import annotations`.
+
+---
+
+# ISCC Content Provenance
+
+**Date**: 2026-07-13
+**Spec**: `docs/superpowers/specs/2026-07-13-iscc-provenance-design.md`
+
+Records ISO 24138 pixel-content codes so a published annotation dataset can be verified.
+
+- `source_iscc` — content code of the source image's **raw OMERO pixels**
+- `label_iscc` — content code of the annotation mask
+
+Both are `Optional[str]` fields on `ImageAnnotation`, so they land in `config.yaml`
+and mirror into the OMERO tracking table automatically.
+
+## The one thing to remember
+
+IMAGEWALK (iscc-bio) is an **exact** code, not a transform-invariant one. It packs raw
+dtype bytes with no bit-depth or intensity canonicalization, matching OMERO's own pixel
+representation bit-for-bit. So it survives a change of **container format** (OME-TIFF ↔
+Zarr ↔ OMERO) but **not** a change of **pixel values**.
+
+The export path rescales intensities (`img * 255/max`) and restacks channels, so the
+8-bit training tiles have codes that do **not** match their source images. Never code the
+tiles — they are ephemeral micro-SAM/CellPose scratch and are never published. Codes come
+from raw source pixels only.
+
+## Usage
+
+```python
+from omero_annotate_ai.processing.provenance import stamp_config, verify_config
+
+# Stamp: fills codes; safe to re-run on an old config.yaml to add provenance
+# retroactively. Codes each unique image once, not once per annotation row.
+stamp_config(config, conn)
+
+# Verify as the author, against the live server:
+result = verify_config(config, conn=conn)
+
+# Verify as a recipient, fully offline, no OMERO:
+result = verify_config(config, data_dir="published_data/")
+print(result.summary)
+```
+
+Offline verification is content-addressed: every image (and `.zarr` store) under
+`data_dir` is coded, and each stored code must appear in that set. Filenames are never
+consulted, so renaming a published file does not break verification. A file that cannot
+be read produces a warning ("verification incomplete"), not a mismatch.
+
+Mismatch is an **error**; a code that was never stamped is a **warning** — absence of
+evidence is not evidence of tampering.
+
+`verify_config` also refuses (rather than returning a verdict) when it cannot verify at
+all: a `data_dir` that is not a directory raises `ValueError`, and a `data_dir` in which
+*nothing codeable* is found raises `RuntimeError`. Otherwise an empty scan — a typo'd
+path, an empty folder — would make every stored code look absent and be reported as a
+mismatch, which is the same "accuse good data" bug in a different disguise. A `data_dir`
+pointing directly *at* a `.zarr` store root is coded as that store, not scanned.
+
+## `stamp_config` vs `verify_config`: deliberately asymmetric failure behaviour
+
+When `iscc-bio` is not installed:
+
+- **`stamp_config` stays best-effort and silent.** Codes stay `None`, one warning is
+  logged, and the annotation run is never harmed. Stamping is a nice-to-have during a run.
+- **`verify_config` raises `RuntimeError`** with an install hint, in *both* `conn` and
+  `data_dir` modes. It does not return a `ValidationResult`. Verifying is the whole point
+  of this feature: with the library absent nothing can actually be recomputed, so a
+  returned "result" would be a verdict with nothing behind it. (An earlier version
+  returned a result here and reported every image as a *mismatch* — i.e. it accused good,
+  untampered data of being tampered with. A verdict you cannot back up is worse than no
+  verdict.)
+
+## Install
+
+`iscc-bio` is optional and pinned `>=0.1,<0.2` (it is PoC software that declares breaking
+changes may ship at any time):
+
+```bash
+pip install 'omero-annotate-ai[provenance]'
+```
+
+Without it, stamping runs unchanged, codes stay `None`, and one warning is logged;
+verifying raises instead (see above). Set `iscc_mode: "on"` in the config to enable
+stamping from the pipeline — it is **off** by default.
+
+## Pipeline hook
+
+`AnnotationPipeline._stamp_provenance()` is called at the top of `_finalize_workflow()`
+(`annotation_pipeline.py`), before `_auto_save_config()`. It is a no-op unless
+`config.iscc_mode == "on"`, and it swallows any exception from `stamp_config()` (printing
+a warning) so provenance can never cost us the annotations. Both `run_microsam_annotation`
+and `run_custom_annotation` converge on `_finalize_workflow`, so this covers both. Note:
+`run_cellpose_preparation` does not route through `_finalize_workflow` (it only prepares
+local tiles and produces no masks), so it is not stamped — Cellpose datasets get
+provenance through the retroactive `stamp_config()` path instead.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,6 +294,34 @@ tags: ["segmentation", "nuclei", "micro-sam", "AI-ready"]
 annotations: []  # List of ImageAnnotation records
 ```
 
+### Content Provenance (ISCC)
+
+Optional [ISO 24138](https://www.iso.org/standard/77899.html) content-provenance codes, computed via the `iscc-bio` library (`pip install 'omero-annotate-ai[provenance]'`):
+
+```yaml
+iscc_mode: "off"    # "off" (default) or "on"
+```
+
+- **`iscc_mode`**: When `"on"`, the pipeline computes an ISCC content code for each
+  annotation's source image and mask after processing, and stores them on the
+  annotation record. When `"off"` (the default), no codes are computed and there is
+  no added per-image compute cost.
+
+When enabled, each entry in `annotations` carries two additional fields:
+
+```yaml
+annotations:
+  - image_id: 101
+    source_iscc: "ISCC:..."   # content code of the source image's raw OMERO pixels
+    label_iscc: "ISCC:..."    # content code of the annotation mask
+```
+
+- **`source_iscc`** / **`label_iscc`**: `Optional[str]`, `null` until stamped. Both
+  round-trip through `config.yaml` and mirror into the OMERO tracking table.
+
+See the [Content Provenance tutorial](tutorials/provenance.md) for the full stamp/verify
+workflow, including fully offline verification.
+
 ## Working with Configuration Files
 
 ### Loading Configurations

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,6 +57,22 @@ conda install -c conda-forge micro-sam napari zeroc-ice
 pip install omero-annotate-ai
 ```
 
+## Optional: Content Provenance (ISCC)
+
+To record [ISO 24138](https://www.iso.org/standard/77899.html) content-provenance codes for published annotation datasets, install the `provenance` extra:
+
+```bash
+pip install 'omero-annotate-ai[provenance]'
+
+# Or with pixi
+pixi add --pypi 'omero-annotate-ai[provenance]'
+```
+
+This pulls in `iscc-bio`, pinned tightly (`>=0.1,<0.2`) because it is a proof-of-concept
+library that may ship breaking changes at any time. Without this extra, the package
+works normally — provenance stamping is simply skipped with a warning. See the
+[Content Provenance tutorial](tutorials/provenance.md) for usage.
+
 ## Quick Start
 
 After installation, try connecting to OMERO:

--- a/docs/superpowers/plans/2026-07-13-iscc-provenance.md
+++ b/docs/superpowers/plans/2026-07-13-iscc-provenance.md
@@ -1,0 +1,1346 @@
+# ISCC Content Provenance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record ISO 24138 pixel-content codes for the source images and annotation masks of an annotation dataset in `config.yaml`, so a recipient can verify offline which images the annotations came from and that the masks are unmodified.
+
+**Architecture:** All ISCC logic lives in one new unit, `processing/provenance.py`, which wraps `iscc-bio` behind guarded imports. Two new `Optional[str]` fields on `ImageAnnotation` (`source_iscc`, `label_iscc`) carry the codes, so they serialize into `config.yaml` and mirror into the OMERO tracking table for free. A `stamp_config()` fills them (during a run, or retroactively on an old config), and `verify_config()` re-checks them either against OMERO or fully offline against a directory of files.
+
+**Tech Stack:** Python ≥3.10, pydantic v2, pandas, ezomero, `iscc-bio` (optional extra), pytest.
+
+## Global Constraints
+
+- `iscc-bio` is an **optional** dependency, pinned `>=0.1,<0.2` — it is PoC software that declares breaking changes may land in any release.
+- `iscc-bio` is imported **lazily, inside functions**, never at module top level. The package must import and run with it absent.
+- Provenance is **best-effort and must never fail an annotation run.** Any compute error yields `None` for that code plus a warning; the run continues.
+- Default is **off**: `iscc_mode: Literal["off", "on"] = "off"`. No compute, no import attempt, zero behaviour change for existing users.
+- Codes are computed on **raw source pixels only** — never on the exported 8-bit training tiles. Export rescales intensities (`img * 255/max`) and restacks channels, so tile codes would not match the source.
+- Optional `Optional[str]` fields round-trip through the OMERO table via the `"None"` sentinel-string pattern already used for timestamps (`annotation_config.py:996-1003`).
+- Tests run with `pixi run -e dev pytest tests/ -v`.
+- `pixi.lock` must be refreshed (`pixi install`) and committed before any PR, or CI fails.
+
+**iscc-bio public API** (verified against the source; use exactly this):
+
+```python
+from iscc_bio.api import biocode
+
+biocode(source="image.ome.tiff")        # local file
+biocode(conn=blitz_gateway, iid=123)    # OMERO image
+
+# returns: List[Dict[str, Any]], one entry per scene
+# [{"iscc_code": "ISCC:...", "units": ["ISCC:...", "ISCC:..."]}]
+```
+
+---
+
+### Task 1: Provenance unit — code computation
+
+**Files:**
+- Create: `src/omero_annotate_ai/processing/provenance.py`
+- Create: `tests/test_provenance.py`
+- Modify: `pyproject.toml:49-67` (add the `provenance` optional-dependency group)
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces:
+  - `iscc_available() -> bool`
+  - `compute_file_iscc(path: str | Path) -> Optional[str]`
+  - `compute_image_iscc(conn, image_id: int) -> Optional[str]`
+  - `compute_label_iscc(conn, label_id: int) -> Optional[str]`
+
+The `provenance` extra is added here because this task's module is the thing that needs the dependency declared.
+
+- [ ] **Step 1: Add the optional-dependency group**
+
+In `pyproject.toml`, inside `[project.optional-dependencies]`, after the `microsam` group (ends line 60), add:
+
+```toml
+provenance = [
+    # ISO 24138 pixel-content codes for dataset provenance.
+    # Pinned tightly: iscc-bio is a proof of concept and declares that breaking
+    # changes may be released at any time.
+    "iscc-bio>=0.1,<0.2",
+]
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tests/test_provenance.py`. `iscc-bio` is an optional dep that will not be installed in CI, so every test fakes it by injecting a stub module into `sys.modules`.
+
+```python
+"""Tests for ISCC content provenance (processing/provenance.py)."""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from omero_annotate_ai.processing import provenance
+
+
+@pytest.fixture
+def fake_iscc(monkeypatch):
+    """Inject a stub iscc_bio module and hand back its biocode mock.
+
+    provenance.py imports iscc_bio lazily inside functions, so patching
+    sys.modules is enough - no real install needed.
+    """
+    biocode = MagicMock(
+        return_value=[{"iscc_code": "ISCC:AAA", "units": ["ISCC:D", "ISCC:I"]}]
+    )
+    api_mod = types.ModuleType("iscc_bio.api")
+    api_mod.biocode = biocode
+    root_mod = types.ModuleType("iscc_bio")
+    root_mod.api = api_mod
+    monkeypatch.setitem(sys.modules, "iscc_bio", root_mod)
+    monkeypatch.setitem(sys.modules, "iscc_bio.api", api_mod)
+    return biocode
+
+
+@pytest.fixture
+def no_iscc(monkeypatch):
+    """Make `import iscc_bio` raise ImportError, simulating it not installed."""
+    monkeypatch.setitem(sys.modules, "iscc_bio", None)
+
+
+@pytest.mark.unit
+class TestIsccAvailability:
+    """Guarded-import behaviour."""
+
+    def test_available_when_installed(self, fake_iscc):
+        assert provenance.iscc_available() is True
+
+    def test_unavailable_when_missing(self, no_iscc):
+        assert provenance.iscc_available() is False
+
+
+@pytest.mark.unit
+class TestComputeFileIscc:
+    """compute_file_iscc()."""
+
+    def test_returns_code_for_file(self, fake_iscc, tmp_path):
+        img = tmp_path / "image.tif"
+        img.write_bytes(b"fake")
+
+        assert provenance.compute_file_iscc(img) == "ISCC:AAA"
+        fake_iscc.assert_called_once_with(source=str(img))
+
+    def test_returns_none_when_iscc_missing(self, no_iscc, tmp_path):
+        img = tmp_path / "image.tif"
+        img.write_bytes(b"fake")
+
+        assert provenance.compute_file_iscc(img) is None
+
+    def test_returns_none_on_compute_error(self, fake_iscc, tmp_path):
+        fake_iscc.side_effect = RuntimeError("unreadable")
+        img = tmp_path / "image.tif"
+        img.write_bytes(b"fake")
+
+        assert provenance.compute_file_iscc(img) is None
+
+    def test_returns_none_on_empty_result(self, fake_iscc, tmp_path):
+        fake_iscc.return_value = []
+        img = tmp_path / "image.tif"
+        img.write_bytes(b"fake")
+
+        assert provenance.compute_file_iscc(img) is None
+
+
+@pytest.mark.unit
+class TestComputeImageIscc:
+    """compute_image_iscc() - the canonical source-side code, from raw OMERO pixels."""
+
+    def test_returns_code_for_omero_image(self, fake_iscc):
+        conn = MagicMock()
+
+        assert provenance.compute_image_iscc(conn, 123) == "ISCC:AAA"
+        fake_iscc.assert_called_once_with(conn=conn, iid=123)
+
+    def test_returns_none_when_iscc_missing(self, no_iscc):
+        assert provenance.compute_image_iscc(MagicMock(), 123) is None
+
+    def test_returns_none_on_omero_error(self, fake_iscc):
+        fake_iscc.side_effect = RuntimeError("connection lost")
+
+        assert provenance.compute_image_iscc(MagicMock(), 123) is None
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pixi run -e dev pytest tests/test_provenance.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'omero_annotate_ai.processing.provenance'`
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/omero_annotate_ai/processing/provenance.py`:
+
+```python
+"""ISCC content provenance for published annotation datasets.
+
+Computes ISO 24138:2024 content codes via iscc-bio's IMAGEWALK traversal.
+
+IMAGEWALK is an *exact* code: it packs raw dtype bytes with no bit-depth or
+intensity canonicalization, aiming for bit-for-bit identity with OMERO's own
+pixel representation. It therefore survives a change of container format
+(OME-TIFF / OME-Zarr / OMERO) but NOT a change of pixel values.
+
+Consequence: codes are computed on raw source pixels only. The exported 8-bit
+training tiles are rescaled (img * 255/max) and channel-restacked, so their
+codes would not match the source, and they are never coded here.
+
+iscc-bio is an optional dependency and is imported lazily. Everything in this
+module degrades to None with a warning when it is absent.
+"""
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+_MISSING_MSG = (
+    "iscc-bio is not installed; skipping ISCC provenance. "
+    "Install it with: pip install 'omero-annotate-ai[provenance]'"
+)
+
+
+def _get_biocode():
+    """Return iscc_bio.api.biocode, or None if iscc-bio is not installed."""
+    try:
+        from iscc_bio.api import biocode
+    except ImportError:
+        return None
+    return biocode
+
+
+def iscc_available() -> bool:
+    """Whether iscc-bio is importable and provenance can be computed."""
+    return _get_biocode() is not None
+
+
+def _first_code(results: Optional[List[Dict[str, Any]]]) -> Optional[str]:
+    """Take the ISCC of the first scene.
+
+    biocode() returns one entry per scene. OMERO images and the exported masks
+    are single-scene, so the first entry is the one we want.
+    """
+    if not results:
+        return None
+    return results[0].get("iscc_code")
+
+
+def compute_file_iscc(path: Union[str, Path]) -> Optional[str]:
+    """Content code for a local image file. Returns None on any failure."""
+    biocode = _get_biocode()
+    if biocode is None:
+        logger.warning(_MISSING_MSG)
+        return None
+
+    try:
+        return _first_code(biocode(source=str(path)))
+    except Exception as exc:  # provenance is best-effort, never fatal
+        logger.warning(f"Could not compute ISCC for file {path}: {exc}")
+        return None
+
+
+def compute_image_iscc(conn, image_id: int) -> Optional[str]:
+    """Content code for an OMERO image, from its raw pixels.
+
+    This is the canonical source-side code: iscc-bio reads OMERO's pixel data
+    directly, so it is directly comparable to any faithful copy of the image.
+    """
+    biocode = _get_biocode()
+    if biocode is None:
+        logger.warning(_MISSING_MSG)
+        return None
+
+    try:
+        return _first_code(biocode(conn=conn, iid=int(image_id)))
+    except Exception as exc:
+        logger.warning(f"Could not compute ISCC for OMERO image {image_id}: {exc}")
+        return None
+
+
+def compute_label_iscc(conn, label_id: int) -> Optional[str]:
+    """Content code for an annotation mask.
+
+    Masks are stored as OMERO file annotations, so this downloads the mask to a
+    temporary directory and codes it as a file.
+    """
+    biocode = _get_biocode()
+    if biocode is None:
+        logger.warning(_MISSING_MSG)
+        return None
+
+    import ezomero
+
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mask_path = ezomero.get_file_annotation(
+                conn, int(label_id), folder_path=tmp_dir
+            )
+            if mask_path is None:
+                logger.warning(f"Label file annotation {label_id} could not be fetched")
+                return None
+            return compute_file_iscc(mask_path)
+    except Exception as exc:
+        logger.warning(f"Could not compute ISCC for label {label_id}: {exc}")
+        return None
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pixi run -e dev pytest tests/test_provenance.py -v`
+Expected: PASS — 9 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/omero_annotate_ai/processing/provenance.py tests/test_provenance.py pyproject.toml
+git commit -m "feat(provenance): add ISCC code computation via iscc-bio
+
+Lazily-imported wrapper around iscc-bio's biocode(). Degrades to None with a
+warning when the optional [provenance] extra is not installed.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Schema fields and table round-trip
+
+**Files:**
+- Modify: `src/omero_annotate_ai/core/annotation_config.py` — `ImageAnnotation` (`:58-117`), `AnnotationConfig` (`:683`), `to_dataframe()` (`:842-943`), `from_dataframe()` (`:945-1005`), `get_config_template()` (`:1323`)
+- Modify: `src/omero_annotate_ai/omero/omero_functions.py:334-337` (`_prepare_dataframe_for_omero`)
+- Test: `tests/test_config.py`, `tests/test_omero_functions.py`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (independent).
+- Produces:
+  - `ImageAnnotation.source_iscc: Optional[str]`
+  - `ImageAnnotation.label_iscc: Optional[str]`
+  - `AnnotationConfig.iscc_mode: Literal["off", "on"]`
+
+Both codes are `Optional[str]`, so they use the **sentinel-string** convention the timestamps already use: `"None"` in the DataFrame, `None` on the model.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_config.py`:
+
+```python
+@pytest.mark.unit
+class TestIsccProvenanceFields:
+    """source_iscc / label_iscc round-trip and iscc_mode toggle."""
+
+    def test_iscc_fields_default_to_none(self):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        ann = ImageAnnotation(image_id=1, image_name="a.tif")
+
+        assert ann.source_iscc is None
+        assert ann.label_iscc is None
+
+    def test_iscc_mode_defaults_to_off(self):
+        from omero_annotate_ai.core.annotation_config import create_default_config
+
+        assert create_default_config().iscc_mode == "off"
+
+    def test_schema_version_bumped(self):
+        from omero_annotate_ai.core.annotation_config import create_default_config
+
+        assert create_default_config().schema_version == "2.1.0"
+
+    def test_old_schema_config_still_loads(self):
+        """2.0.0 configs predate the ISCC fields; they must still load, unstamped."""
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        ann = ImageAnnotation(image_id=1, image_name="a.tif")
+
+        assert ann.source_iscc is None
+
+    def test_iscc_fields_survive_yaml_round_trip(self, tmp_path):
+        from omero_annotate_ai.core.annotation_config import (
+            AnnotationConfig,
+            ImageAnnotation,
+            create_default_config,
+        )
+
+        config = create_default_config()
+        config.iscc_mode = "on"
+        config.add_annotation(
+            ImageAnnotation(
+                image_id=1,
+                image_name="a.tif",
+                source_iscc="ISCC:SOURCE",
+                label_iscc="ISCC:LABEL",
+            )
+        )
+
+        path = tmp_path / "config.yaml"
+        config.save_yaml(path)
+        loaded = AnnotationConfig.from_yaml(path)
+
+        assert loaded.iscc_mode == "on"
+        assert loaded.annotations[0].source_iscc == "ISCC:SOURCE"
+        assert loaded.annotations[0].label_iscc == "ISCC:LABEL"
+
+    def test_iscc_fields_survive_dataframe_round_trip(self):
+        from omero_annotate_ai.core.annotation_config import (
+            ImageAnnotation,
+            create_default_config,
+        )
+
+        config = create_default_config()
+        config.add_annotation(
+            ImageAnnotation(
+                image_id=1,
+                image_name="a.tif",
+                source_iscc="ISCC:SOURCE",
+                label_iscc="ISCC:LABEL",
+            )
+        )
+
+        df = config.to_dataframe()
+        assert df.loc[0, "source_iscc"] == "ISCC:SOURCE"
+        assert df.loc[0, "label_iscc"] == "ISCC:LABEL"
+
+        reloaded = create_default_config()
+        reloaded.from_dataframe(df)
+
+        assert reloaded.annotations[0].source_iscc == "ISCC:SOURCE"
+        assert reloaded.annotations[0].label_iscc == "ISCC:LABEL"
+
+    def test_absent_codes_round_trip_as_none(self):
+        """An unstamped annotation must come back as None, not the string 'None'."""
+        from omero_annotate_ai.core.annotation_config import (
+            ImageAnnotation,
+            create_default_config,
+        )
+
+        config = create_default_config()
+        config.add_annotation(ImageAnnotation(image_id=1, image_name="a.tif"))
+
+        df = config.to_dataframe()
+        assert df.loc[0, "source_iscc"] == "None"
+
+        reloaded = create_default_config()
+        reloaded.from_dataframe(df)
+
+        assert reloaded.annotations[0].source_iscc is None
+        assert reloaded.annotations[0].label_iscc is None
+```
+
+Add to `tests/test_omero_functions.py`:
+
+```python
+@pytest.mark.unit
+class TestIsccColumnTyping:
+    """_prepare_dataframe_for_omero() types the ISCC columns as strings."""
+
+    def test_iscc_columns_typed_as_string(self):
+        import pandas as pd
+
+        from omero_annotate_ai.omero.omero_functions import _prepare_dataframe_for_omero
+
+        df = pd.DataFrame(
+            {
+                "image_id": [1, 2],
+                "source_iscc": ["ISCC:SOURCE", None],
+                "label_iscc": [None, "ISCC:LABEL"],
+            }
+        )
+
+        result = _prepare_dataframe_for_omero(df)
+
+        assert result["source_iscc"].tolist() == ["ISCC:SOURCE", "None"]
+        assert result["label_iscc"].tolist() == ["None", "ISCC:LABEL"]
+        assert result["source_iscc"].dtype == object
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pixi run -e dev pytest tests/test_config.py::TestIsccProvenanceFields tests/test_omero_functions.py::TestIsccColumnTyping -v`
+Expected: FAIL — pydantic rejects the unknown `source_iscc` field / `KeyError: 'source_iscc'`
+
+- [ ] **Step 3: Add the model fields**
+
+In `annotation_config.py`, in `ImageAnnotation`, immediately after the `schema_attachment_id` field (ends line 111) and before the `channel_presentation` field:
+
+```python
+    # ISCC content provenance (None until stamped; see processing/provenance.py)
+    source_iscc: Optional[str] = Field(
+        default=None,
+        description="ISO 24138 content code of the source image's raw OMERO pixels",
+    )
+    label_iscc: Optional[str] = Field(
+        default=None,
+        description="ISO 24138 content code of the annotation mask",
+    )
+```
+
+In `AnnotationConfig` (`:683`), alongside the other top-level settings, add:
+
+```python
+    iscc_mode: Literal["off", "on"] = Field(
+        default="off",
+        description="Compute ISCC content provenance during a run. Requires the "
+        "'provenance' extra. Off by default: adds per-image compute cost.",
+    )
+```
+
+- [ ] **Step 4: Add the codes to `to_dataframe()`**
+
+In `to_dataframe()`, in the `row` dict (after `"z_length": annotation.z_length,`, line 881), add — reusing the `"None"` sentinel the timestamps use:
+
+```python
+                "source_iscc": annotation.source_iscc or "None",
+                "label_iscc": annotation.label_iscc or "None",
+```
+
+And append to the `columns` list (after `"z_length",`, line 910):
+
+```python
+            "source_iscc",
+            "label_iscc",
+```
+
+- [ ] **Step 5: Add the codes to `from_dataframe()`**
+
+In `from_dataframe()`, after the timestamp handling (after line 1003, before `self.add_annotation(...)`), add:
+
+```python
+            # ISCC provenance codes - "None" sentinel means not yet stamped
+            source_iscc_str = str(row.get("source_iscc", "None"))
+            if source_iscc_str != "None":
+                annotation_data["source_iscc"] = source_iscc_str
+
+            label_iscc_str = str(row.get("label_iscc", "None"))
+            if label_iscc_str != "None":
+                annotation_data["label_iscc"] = label_iscc_str
+```
+
+- [ ] **Step 6: Type the columns for OMERO**
+
+In `omero_functions.py`, in `_prepare_dataframe_for_omero`, after the `datetime_columns` block (ends line 337), add:
+
+```python
+    iscc_columns = ["source_iscc", "label_iscc"]
+    for col in iscc_columns:
+        if col in df.columns:
+            df[col] = df[col].fillna("None").astype(str)
+```
+
+- [ ] **Step 7: Bump the schema version**
+
+Two new fields change the config schema, so bump the minor version. In `annotation_config.py:687`, change the `schema_version` default from `"2.0.0"` to `"2.1.0"`, and change the matching line in the template at `:1327` from `schema_version: "2.0.0"` to `schema_version: "2.1.0"`.
+
+The bump is minor, not major: both fields default to `None`, so a 2.0.0 config still loads unchanged.
+
+- [ ] **Step 8: Document in the config template**
+
+In `get_config_template()` (`:1323`), add to the commented template:
+
+```yaml
+# ISCC content provenance (ISO 24138). Requires: pip install 'omero-annotate-ai[provenance]'
+# When "on", each annotation records the content code of its source image
+# (source_iscc) and mask (label_iscc), so a published dataset can be verified
+# offline. Off by default.
+iscc_mode: off
+```
+
+- [ ] **Step 9: Run the tests to verify they pass**
+
+Run: `pixi run -e dev pytest tests/test_config.py tests/test_omero_functions.py -v`
+Expected: PASS — all tests, including the new `TestIsccProvenanceFields` (7 tests) and `TestIsccColumnTyping` (1 test)
+
+- [ ] **Step 10: Run the full suite for regressions**
+
+Run: `pixi run -e dev pytest tests/ -v`
+Expected: PASS — the two new columns must not break any existing table test. If an existing test asserts an exact column count or an exact `schema_version` string, update it to the new values.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/omero_annotate_ai/core/annotation_config.py src/omero_annotate_ai/omero/omero_functions.py tests/test_config.py tests/test_omero_functions.py
+git commit -m "feat(provenance): add source_iscc/label_iscc fields and iscc_mode
+
+Codes serialize into config.yaml and mirror into the OMERO tracking table.
+Absent codes use the 'None' sentinel-string convention already used by the
+timestamp columns.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `stamp_config()` — fill the codes
+
+**Files:**
+- Modify: `src/omero_annotate_ai/processing/provenance.py`
+- Test: `tests/test_provenance.py`
+
+**Interfaces:**
+- Consumes: `compute_image_iscc`, `compute_label_iscc`, `iscc_available` (Task 1); `ImageAnnotation.source_iscc`, `.label_iscc` (Task 2).
+- Produces: `stamp_config(config: AnnotationConfig, conn) -> AnnotationConfig` — mutates and returns the config.
+
+Caching is the point of this task: a source image is shared by many annotation rows (every patch, z-slice and timepoint of one image), so it must be coded **once**, not once per row.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_provenance.py`:
+
+```python
+def _config_with(annotations):
+    """Build a default config carrying the given annotations."""
+    from omero_annotate_ai.core.annotation_config import create_default_config
+
+    config = create_default_config()
+    for ann in annotations:
+        config.add_annotation(ann)
+    return config
+
+
+@pytest.mark.unit
+class TestStampConfig:
+    """stamp_config() fills codes, and codes each unique id exactly once."""
+
+    def test_fills_source_and_label_codes(self, fake_iscc, monkeypatch):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        monkeypatch.setattr(provenance, "compute_label_iscc", lambda conn, lid: "ISCC:LBL")
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", label_id=99)]
+        )
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert config.annotations[0].source_iscc == "ISCC:AAA"
+        assert config.annotations[0].label_iscc == "ISCC:LBL"
+
+    def test_codes_each_source_image_only_once(self, fake_iscc):
+        """Three patches of one image must trigger exactly one OMERO compute."""
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        config = _config_with(
+            [
+                ImageAnnotation(image_id=7, image_name="a.tif", is_patch=True, patch_x=0),
+                ImageAnnotation(image_id=7, image_name="a.tif", is_patch=True, patch_x=1),
+                ImageAnnotation(image_id=7, image_name="a.tif", is_patch=True, patch_x=2),
+            ]
+        )
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert fake_iscc.call_count == 1
+        assert all(a.source_iscc == "ISCC:AAA" for a in config.annotations)
+
+    def test_skips_annotations_without_a_label(self, fake_iscc):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        config = _config_with([ImageAnnotation(image_id=7, image_name="a.tif")])
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert config.annotations[0].source_iscc == "ISCC:AAA"
+        assert config.annotations[0].label_iscc is None
+
+    def test_does_not_recompute_existing_codes(self, fake_iscc):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:OLD")]
+        )
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert config.annotations[0].source_iscc == "ISCC:OLD"
+        assert fake_iscc.call_count == 0
+
+    def test_no_op_and_warns_when_iscc_missing(self, no_iscc, caplog):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        config = _config_with([ImageAnnotation(image_id=7, image_name="a.tif")])
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert config.annotations[0].source_iscc is None
+        assert "iscc-bio is not installed" in caplog.text
+
+    def test_one_failing_image_does_not_abort_the_pass(self, fake_iscc):
+        """A broken image must not cost us the codes of the healthy ones."""
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        def flaky(conn=None, iid=None, **kwargs):
+            if iid == 7:
+                raise RuntimeError("corrupt pixels")
+            return [{"iscc_code": "ISCC:OK"}]
+
+        fake_iscc.side_effect = flaky
+        config = _config_with(
+            [
+                ImageAnnotation(image_id=7, image_name="bad.tif"),
+                ImageAnnotation(image_id=8, image_name="good.tif"),
+            ]
+        )
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert config.annotations[0].source_iscc is None
+        assert config.annotations[1].source_iscc == "ISCC:OK"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pixi run -e dev pytest tests/test_provenance.py::TestStampConfig -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'stamp_config'`
+
+- [ ] **Step 3: Implement `stamp_config`**
+
+Append to `src/omero_annotate_ai/processing/provenance.py`:
+
+```python
+def stamp_config(config, conn):
+    """Fill in source_iscc and label_iscc for every annotation in the config.
+
+    Safe to re-run: codes that are already present are left alone, so this can
+    be pointed at an existing config.yaml from a previous run to add provenance
+    retroactively.
+
+    Each unique image_id and label_id is coded once and cached - a source image
+    is typically shared by many annotation rows (patches, z-slices, timepoints),
+    and coding it per row would be wasteful.
+
+    Args:
+        config: AnnotationConfig to stamp, mutated in place.
+        conn: OMERO BlitzGateway connection.
+
+    Returns:
+        The same config, for chaining.
+    """
+    if not iscc_available():
+        logger.warning(_MISSING_MSG)
+        return config
+
+    image_cache: Dict[int, Optional[str]] = {}
+    label_cache: Dict[int, Optional[str]] = {}
+
+    for annotation in config.annotations:
+        if annotation.source_iscc is None:
+            image_id = annotation.image_id
+            if image_id not in image_cache:
+                image_cache[image_id] = compute_image_iscc(conn, image_id)
+            annotation.source_iscc = image_cache[image_id]
+
+        if annotation.label_iscc is None and annotation.label_id is not None:
+            label_id = annotation.label_id
+            if label_id not in label_cache:
+                label_cache[label_id] = compute_label_iscc(conn, label_id)
+            annotation.label_iscc = label_cache[label_id]
+
+    coded = sum(1 for a in config.annotations if a.source_iscc is not None)
+    logger.info(
+        f"Stamped ISCC provenance: {coded}/{len(config.annotations)} annotations, "
+        f"{len(image_cache)} unique source image(s)"
+    )
+    return config
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pixi run -e dev pytest tests/test_provenance.py -v`
+Expected: PASS — 15 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/omero_annotate_ai/processing/provenance.py tests/test_provenance.py
+git commit -m "feat(provenance): add stamp_config to fill ISCC codes
+
+Codes each unique image_id/label_id once. Idempotent, so it can retroactively
+stamp a config.yaml from a run that predates this feature.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `verify_config()` — check the codes, including fully offline
+
+**Files:**
+- Modify: `src/omero_annotate_ai/processing/provenance.py`
+- Test: `tests/test_provenance.py`
+
+**Interfaces:**
+- Consumes: `compute_file_iscc`, `compute_image_iscc`, `compute_label_iscc` (Task 1); the schema fields (Task 2).
+- Produces: `verify_config(config, conn=None, data_dir=None) -> ValidationResult`
+
+Two modes, exactly one of which must be supplied:
+
+- `conn` — re-fetch from OMERO and recompute. The author's own check.
+- `data_dir` — **offline**, no OMERO at all. This is the mode a recipient of the published dataset runs, and it is the reason the whole feature exists.
+
+The offline mode is **content-addressed, not filename-addressed**: it codes every image file under `data_dir` and asks whether each stored code is present in that set. Renaming a published file therefore does not break verification, which is precisely the property ISCC gives us.
+
+Three outcomes per annotation, mapped onto the existing `ValidationResult` (`annotation_config.py:1145`):
+
+| Outcome | Meaning | Recorded as |
+|---|---|---|
+| match | recomputed code equals the stored one | nothing |
+| mismatch | stored code is absent from the data / differs | **error** (`is_valid` → False) |
+| missing | no code was ever stored | **warning** |
+
+A missing code is an absence of evidence, not evidence of tampering, and must never be reported as a failure.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_provenance.py`:
+
+```python
+@pytest.mark.unit
+class TestVerifyConfigArguments:
+    """verify_config() demands exactly one source of truth."""
+
+    def test_rejects_neither_conn_nor_data_dir(self, fake_iscc):
+        config = _config_with([])
+
+        with pytest.raises(ValueError, match="exactly one"):
+            provenance.verify_config(config)
+
+    def test_rejects_both_conn_and_data_dir(self, fake_iscc, tmp_path):
+        config = _config_with([])
+
+        with pytest.raises(ValueError, match="exactly one"):
+            provenance.verify_config(config, conn=MagicMock(), data_dir=tmp_path)
+
+
+@pytest.mark.unit
+class TestVerifyConfigOffline:
+    """data_dir mode - the recipient's story. No OMERO connection at all."""
+
+    def test_match_when_published_file_carries_the_stored_code(
+        self, fake_iscc, tmp_path
+    ):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        (tmp_path / "published.tif").write_bytes(b"fake")
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        result = provenance.verify_config(config, data_dir=tmp_path)
+
+        assert result.is_valid is True
+        assert result.errors == []
+
+    def test_mismatch_when_stored_code_absent_from_data(self, fake_iscc, tmp_path):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        (tmp_path / "published.tif").write_bytes(b"fake")
+        config = _config_with(
+            [
+                ImageAnnotation(
+                    image_id=7, image_name="a.tif", source_iscc="ISCC:DIFFERENT"
+                )
+            ]
+        )
+
+        result = provenance.verify_config(config, data_dir=tmp_path)
+
+        assert result.is_valid is False
+        assert len(result.errors) == 1
+        assert "source_iscc" in result.errors[0].field
+
+    def test_missing_is_a_warning_not_an_error(self, fake_iscc, tmp_path):
+        """No stored code is absence of evidence, not evidence of tampering."""
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        (tmp_path / "published.tif").write_bytes(b"fake")
+        config = _config_with([ImageAnnotation(image_id=7, image_name="a.tif")])
+
+        result = provenance.verify_config(config, data_dir=tmp_path)
+
+        assert result.is_valid is True
+        assert result.errors == []
+        assert len(result.warnings) == 1
+
+    def test_label_code_also_verified(self, fake_iscc, tmp_path):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        (tmp_path / "mask.tif").write_bytes(b"fake")
+        config = _config_with(
+            [
+                ImageAnnotation(
+                    image_id=7,
+                    image_name="a.tif",
+                    source_iscc="ISCC:AAA",
+                    label_iscc="ISCC:NOTPRESENT",
+                )
+            ]
+        )
+
+        result = provenance.verify_config(config, data_dir=tmp_path)
+
+        assert result.is_valid is False
+        assert any("label_iscc" in e.field for e in result.errors)
+
+
+@pytest.mark.unit
+class TestVerifyConfigOmero:
+    """conn mode - the author's own check against the live server."""
+
+    def test_match_when_omero_still_has_the_same_pixels(self, fake_iscc):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        result = provenance.verify_config(config, conn=MagicMock())
+
+        assert result.is_valid is True
+
+    def test_mismatch_when_omero_pixels_changed(self, fake_iscc):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        fake_iscc.return_value = [{"iscc_code": "ISCC:CHANGED"}]
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        result = provenance.verify_config(config, conn=MagicMock())
+
+        assert result.is_valid is False
+        assert len(result.errors) == 1
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pixi run -e dev pytest tests/test_provenance.py::TestVerifyConfigOffline -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'verify_config'`
+
+- [ ] **Step 3: Implement `verify_config`**
+
+Append to `src/omero_annotate_ai/processing/provenance.py`:
+
+```python
+# Image formats iscc-bio can read, used when scanning a published data directory.
+_IMAGE_SUFFIXES = {".tif", ".tiff", ".czi", ".nd2", ".lif", ".dv", ".zarr"}
+
+
+def _scan_directory_codes(data_dir: Union[str, Path]) -> set:
+    """Content-code every image file under data_dir.
+
+    Returns a set of codes, deliberately discarding filenames: verification is
+    content-addressed, so renaming a published file must not break it.
+    """
+    codes = set()
+    for path in sorted(Path(data_dir).rglob("*")):
+        if path.is_file() and path.suffix.lower() in _IMAGE_SUFFIXES:
+            code = compute_file_iscc(path)
+            if code is not None:
+                codes.add(code)
+    return codes
+
+
+def verify_config(config, conn=None, data_dir=None):
+    """Verify the ISCC codes stored in a config against actual data.
+
+    Exactly one source must be given:
+      conn:     recompute from OMERO. The author's check against the live server.
+      data_dir: recompute from local files, fully OFFLINE, no OMERO needed. This
+                is what a recipient of a published dataset runs, and it is the
+                reason this feature exists.
+
+    In data_dir mode the check is content-addressed: every image file under the
+    directory is coded, and each stored code must appear somewhere in that set.
+    Filenames are irrelevant.
+
+    Args:
+        config: AnnotationConfig carrying stamped codes.
+        conn: OMERO BlitzGateway, for the online check.
+        data_dir: Directory of published image files, for the offline check.
+
+    Returns:
+        ValidationResult. A mismatch is an error; a code that was never stamped
+        is a warning, because absence of evidence is not evidence of tampering.
+    """
+    from ..core.annotation_config import ValidationIssue, ValidationResult
+
+    if (conn is None) == (data_dir is None):
+        raise ValueError(
+            "verify_config requires exactly one of 'conn' (verify against OMERO) "
+            "or 'data_dir' (verify offline against published files)"
+        )
+
+    errors = []
+    warnings = []
+
+    available_codes = _scan_directory_codes(data_dir) if data_dir is not None else None
+    image_cache: Dict[int, Optional[str]] = {}
+    label_cache: Dict[int, Optional[str]] = {}
+
+    for annotation in config.annotations:
+        label = f"image {annotation.image_id} ({annotation.image_name})"
+
+        # --- source image ---
+        if annotation.source_iscc is None:
+            warnings.append(
+                ValidationIssue(
+                    field="source_iscc",
+                    message=f"No source ISCC stored for {label}; not verifiable. "
+                    "Run stamp_config() to add provenance.",
+                )
+            )
+        elif available_codes is not None:
+            if annotation.source_iscc not in available_codes:
+                errors.append(
+                    ValidationIssue(
+                        field="source_iscc",
+                        message=f"No file in the data directory matches the recorded "
+                        f"source ISCC for {label}. The data does not match the config.",
+                    )
+                )
+        else:
+            image_id = annotation.image_id
+            if image_id not in image_cache:
+                image_cache[image_id] = compute_image_iscc(conn, image_id)
+            actual = image_cache[image_id]
+            if actual is not None and actual != annotation.source_iscc:
+                errors.append(
+                    ValidationIssue(
+                        field="source_iscc",
+                        message=f"Source ISCC mismatch for {label}: config records "
+                        f"{annotation.source_iscc}, OMERO now yields {actual}.",
+                    )
+                )
+
+        # --- annotation mask ---
+        if annotation.label_id is None:
+            continue
+
+        if annotation.label_iscc is None:
+            warnings.append(
+                ValidationIssue(
+                    field="label_iscc",
+                    message=f"No label ISCC stored for {label}; mask not verifiable.",
+                )
+            )
+        elif available_codes is not None:
+            if annotation.label_iscc not in available_codes:
+                errors.append(
+                    ValidationIssue(
+                        field="label_iscc",
+                        message=f"No file in the data directory matches the recorded "
+                        f"label ISCC for {label}. The mask does not match the config.",
+                    )
+                )
+        else:
+            label_id = annotation.label_id
+            if label_id not in label_cache:
+                label_cache[label_id] = compute_label_iscc(conn, label_id)
+            actual = label_cache[label_id]
+            if actual is not None and actual != annotation.label_iscc:
+                errors.append(
+                    ValidationIssue(
+                        field="label_iscc",
+                        message=f"Label ISCC mismatch for {label}: config records "
+                        f"{annotation.label_iscc}, OMERO now yields {actual}.",
+                    )
+                )
+
+    return ValidationResult(
+        is_valid=len(errors) == 0,
+        errors=errors,
+        warnings=warnings,
+        annotation_count=len(config.annotations),
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pixi run -e dev pytest tests/test_provenance.py -v`
+Expected: PASS — 23 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/omero_annotate_ai/processing/provenance.py tests/test_provenance.py
+git commit -m "feat(provenance): add verify_config with offline data_dir mode
+
+Verifies stored ISCC codes against OMERO (conn) or against a directory of
+published files with no OMERO at all (data_dir) - the mode a recipient runs.
+
+Offline verification is content-addressed: every image under data_dir is coded
+and each stored code must appear in that set, so renaming published files does
+not break it.
+
+Mismatch is an error; a never-stamped code is a warning, not a failure.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Pipeline hook, docs, and lockfile
+
+**Files:**
+- Modify: `src/omero_annotate_ai/core/annotation_pipeline.py` (after the annotation run completes, before the config is persisted)
+- Modify: `docs/superpowers/specs/2026-07-13-iscc-provenance-design.md` (correct the offline-verify description)
+- Modify: `CLAUDE.md`
+- Modify: `pixi.lock` (regenerated)
+- Test: `tests/test_pipeline.py`
+
+**Interfaces:**
+- Consumes: `stamp_config` (Task 3); `AnnotationConfig.iscc_mode` (Task 2).
+- Produces: nothing new — this wires the unit into the pipeline.
+
+The hook is deliberately tiny: all the logic lives in `provenance.py`, so the pipeline only decides *whether* to call it. Stamping runs **after** the annotation work is done and `label_id`s exist, so both codes can be filled in one pass.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_pipeline.py`:
+
+```python
+@pytest.mark.unit
+class TestIsccPipelineHook:
+    """The pipeline stamps provenance only when iscc_mode is on."""
+
+    def test_stamp_not_called_when_mode_off(self, monkeypatch):
+        from omero_annotate_ai.core import annotation_pipeline
+        from omero_annotate_ai.core.annotation_config import create_default_config
+
+        called = []
+        monkeypatch.setattr(
+            annotation_pipeline, "stamp_config", lambda c, conn: called.append(c)
+        )
+
+        config = create_default_config()
+        config.iscc_mode = "off"
+        pipeline = annotation_pipeline.AnnotationPipeline(config, MagicMock())
+        pipeline._stamp_provenance()
+
+        assert called == []
+
+    def test_stamp_called_when_mode_on(self, monkeypatch):
+        from omero_annotate_ai.core import annotation_pipeline
+        from omero_annotate_ai.core.annotation_config import create_default_config
+
+        called = []
+        monkeypatch.setattr(
+            annotation_pipeline, "stamp_config", lambda c, conn: called.append(c)
+        )
+
+        config = create_default_config()
+        config.iscc_mode = "on"
+        pipeline = annotation_pipeline.AnnotationPipeline(config, MagicMock())
+        pipeline._stamp_provenance()
+
+        assert len(called) == 1
+
+    def test_stamp_failure_never_breaks_the_run(self, monkeypatch):
+        """Provenance is best-effort. A failure here must not lose annotations."""
+        from omero_annotate_ai.core import annotation_pipeline
+        from omero_annotate_ai.core.annotation_config import create_default_config
+
+        def boom(config, conn):
+            raise RuntimeError("iscc exploded")
+
+        monkeypatch.setattr(annotation_pipeline, "stamp_config", boom)
+
+        config = create_default_config()
+        config.iscc_mode = "on"
+        pipeline = annotation_pipeline.AnnotationPipeline(config, MagicMock())
+
+        pipeline._stamp_provenance()  # must not raise
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pixi run -e dev pytest tests/test_pipeline.py::TestIsccPipelineHook -v`
+Expected: FAIL — `AttributeError: 'AnnotationPipeline' object has no attribute '_stamp_provenance'`
+
+- [ ] **Step 3: Add the import and the hook method**
+
+In `annotation_pipeline.py`, add to the imports at the top of the file:
+
+```python
+from ..processing.provenance import stamp_config
+```
+
+Add this method to `AnnotationPipeline`:
+
+```python
+    def _stamp_provenance(self) -> None:
+        """Record ISCC content provenance for the annotated images and masks.
+
+        No-op unless config.iscc_mode == "on". Best-effort: provenance is a
+        publication concern, and losing it must never cost us the annotations,
+        so any failure is logged and swallowed.
+        """
+        if self.config.iscc_mode != "on":
+            return
+
+        try:
+            stamp_config(self.config, self.conn)
+        except Exception as exc:
+            print(f"⚠️ Could not stamp ISCC provenance: {exc}")
+```
+
+- [ ] **Step 4: Call the hook from `_finalize_workflow`**
+
+`_finalize_workflow` (`annotation_pipeline.py:1482`) is the single convergence point — both `run_microsam_annotation` (`:1524`) and `run_custom_annotation` (`:1949`) end there, and it is where the config is persisted: `_auto_save_config()` at `:1489`, then `_upload_annotation_config_to_omero()` at `:1493`.
+
+Insert the call at the **top** of `_finalize_workflow`, before the `_auto_save_config()` line:
+
+```python
+    def _finalize_workflow(self, processed_count: int) -> None:
+        """Finalize the workflow with cleanup and uploads.
+
+        Args:
+            processed_count: Number of units that were processed
+        """
+        # Stamp ISCC provenance before the config is persisted, so the codes
+        # travel into both config.yaml and the OMERO tracking table.
+        self._stamp_provenance()
+
+        # Final config save
+        self._auto_save_config()
+```
+
+Placement matters and this point satisfies both constraints: it runs **after** the annotation batches have completed and masks are uploaded (so `label_id` is populated), and **before** the config is written out (so the codes are actually saved).
+
+Note: `run_cellpose_preparation` does not route through `_finalize_workflow`, so it is not stamped. That is correct — it only prepares local tiles and produces no masks. Cellpose datasets get provenance through the retroactive `stamp_config()` path instead.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pixi run -e dev pytest tests/test_pipeline.py -v`
+Expected: PASS — including the 3 new `TestIsccPipelineHook` tests
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `pixi run -e dev pytest tests/ -v`
+Expected: PASS — no regressions.
+
+- [ ] **Step 7: Correct the spec's offline-verify description**
+
+The spec described offline verification as mapping each annotation to a file. The implementation is content-addressed instead — better, because it survives renaming. In `docs/superpowers/specs/2026-07-13-iscc-provenance-design.md`, replace:
+
+> The `data_dir` mode is what a third party actually runs: they hold the published images and the
+> `config.yaml`, and nothing else. It maps each annotation's file to `compute_file_iscc` and compares
+> against the stored `source_iscc` / `label_iscc`.
+
+with:
+
+> The `data_dir` mode is what a third party actually runs: they hold the published images and the
+> `config.yaml`, and nothing else. It is **content-addressed**: every image file under the directory is
+> coded, and each stored `source_iscc` / `label_iscc` must appear somewhere in that set. Filenames are
+> never consulted, so renaming a published file does not break verification — which is exactly the
+> property a content code is supposed to give us.
+
+- [ ] **Step 8: Document the feature in CLAUDE.md**
+
+Append a section to `CLAUDE.md`:
+
+```markdown
+---
+
+# ISCC Content Provenance
+
+**Date**: 2026-07-13
+**Spec**: `docs/superpowers/specs/2026-07-13-iscc-provenance-design.md`
+
+Records ISO 24138 pixel-content codes so a published annotation dataset can be verified.
+
+- `source_iscc` — content code of the source image's **raw OMERO pixels**
+- `label_iscc` — content code of the annotation mask
+
+Both are `Optional[str]` fields on `ImageAnnotation`, so they land in `config.yaml`
+and mirror into the OMERO tracking table automatically.
+
+## The one thing to remember
+
+IMAGEWALK (iscc-bio) is an **exact** code, not a transform-invariant one. It packs raw
+dtype bytes with no bit-depth or intensity canonicalization, matching OMERO's own pixel
+representation bit-for-bit. So it survives a change of **container format** (OME-TIFF ↔
+Zarr ↔ OMERO) but **not** a change of **pixel values**.
+
+The export path rescales intensities (`img * 255/max`) and restacks channels, so the
+8-bit training tiles have codes that do **not** match their source images. Never code the
+tiles — they are ephemeral micro-SAM/CellPose scratch and are never published. Codes come
+from raw source pixels only.
+
+## Usage
+
+```python
+from omero_annotate_ai.processing.provenance import stamp_config, verify_config
+
+# Stamp: fills codes; safe to re-run on an old config.yaml to add provenance
+# retroactively. Codes each unique image once, not once per annotation row.
+stamp_config(config, conn)
+
+# Verify as the author, against the live server:
+result = verify_config(config, conn=conn)
+
+# Verify as a recipient, fully offline, no OMERO:
+result = verify_config(config, data_dir="published_data/")
+print(result.summary)
+```
+
+Offline verification is content-addressed: every image under `data_dir` is coded and each
+stored code must appear in that set. Renaming published files does not break it.
+
+Mismatch is an **error**; a code that was never stamped is a **warning** — absence of
+evidence is not evidence of tampering.
+
+## Install
+
+`iscc-bio` is optional and pinned `>=0.1,<0.2` (it is PoC software that declares breaking
+changes may ship at any time):
+
+```bash
+pip install 'omero-annotate-ai[provenance]'
+```
+
+Without it the pipeline runs unchanged, codes stay `None`, and one warning is logged.
+Set `iscc_mode: "on"` in the config to enable — it is **off** by default.
+```
+
+- [ ] **Step 9: Refresh the lockfile**
+
+Run: `pixi install`
+Expected: `pixi.lock` is updated. CI fails if this is skipped.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/omero_annotate_ai/core/annotation_pipeline.py tests/test_pipeline.py CLAUDE.md docs/superpowers/specs/2026-07-13-iscc-provenance-design.md pixi.lock
+git commit -m "feat(provenance): stamp ISCC codes from the pipeline when enabled
+
+Hook runs after masks are uploaded and before the config is persisted, so both
+codes travel into config.yaml and the tracking table. No-op when iscc_mode is
+off (the default); failures are swallowed so provenance can never cost us the
+annotations.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Manual Verification
+
+The unit tests all mock `iscc-bio`, so they prove the wiring but not that the codes are *real*. These steps need a live OMERO and a real install (`pip install 'omero-annotate-ai[provenance]'`).
+
+- [ ] **The core claim — format independence.** Export a **lossless** copy of a source image in a different container format (OME-TIFF → OME-Zarr). Confirm `compute_file_iscc(copy) == compute_image_iscc(conn, image_id)`. The entire design rests on this; if it fails, nothing else matters.
+
+- [ ] **Stamping.** Run an annotation with `iscc_mode: "on"`. Confirm `source_iscc` and `label_iscc` appear in the saved `config.yaml` and in the OMERO tracking table, and that each unique `image_id` was coded once (check the "N unique source image(s)" log line against the number of annotation rows).
+
+- [ ] **The recipient's story.** With **no OMERO connection**, run `verify_config(config, data_dir=...)` against the published images plus `config.yaml` alone. Every entry must report match. This is the story the feature exists for — if it does not work offline, the feature has failed.
+
+- [ ] **Tamper detection.** Alter the pixels of one published file; confirm `verify_config` reports a **mismatch** error. Clear one stored code; confirm it reports a **missing** warning and `is_valid` stays `True`.
+
+- [ ] **Retrofit.** Take a `config.yaml` from a run predating this feature, run `stamp_config(config, conn)`, and confirm both fields populate.
+
+- [ ] **Graceful degradation.** `pip uninstall iscc-bio`. Confirm the pipeline still runs end to end, codes are `None`, and a single clear warning is logged rather than an exception.

--- a/docs/superpowers/specs/2026-07-13-iscc-provenance-design.md
+++ b/docs/superpowers/specs/2026-07-13-iscc-provenance-design.md
@@ -1,0 +1,235 @@
+# ISCC Content Provenance for Published Annotation Datasets
+
+**Date:** 2026-07-13
+**Status:** Approved design, ready for implementation planning
+
+## Problem
+
+When we publish an annotation dataset (original images + annotations), nothing in the record
+identifies the image *content* that was annotated. Image identity is carried only by the OMERO
+`image_id` — an integer that is meaningless outside the originating server, and that says nothing
+about the pixels it points at. A recipient of a published dataset cannot answer:
+
+- Which exact images did these annotations come from?
+- Are the masks I received the ones the authors actually produced?
+
+A repo-wide search confirms there is no fingerprint of any kind today
+(`grep hashlib|md5|sha256|checksum` → zero matches).
+
+## Goal
+
+Publication-grade, citable provenance. A third party receives the published dataset plus its
+`config.yaml` and can verify, **offline and without OMERO access**, both which source images the
+annotations derive from and that the annotation masks are unmodified.
+
+Explicitly *not* goals (see Out of Scope).
+
+## Why ISCC, and why the pixel-level code specifically
+
+ISCC (ISO 24138:2024) is a content-based identifier. Two properties matter here:
+
+1. **`iscc-bio` / IMAGEWALK is pixel-level and format-independent.** It traverses planes
+   deterministically (Z→C→T), flattens each plane row-major, and packs raw dtype bytes big-endian.
+   The same pixels stored as OMERO server pixels, OME-TIFF, or OME-Zarr therefore produce the *same*
+   code. This is what makes an OMERO image and a published copy comparable.
+
+2. **`iscc-sum` is byte-level and is the wrong tool here.** It fingerprints file bytes, so the same
+   pixels in different container formats produce *different* codes. It cannot compare OMERO against a
+   published copy. It is not used in this design.
+
+### Critical property: IMAGEWALK is exact, not transform-invariant
+
+Verified against the `iscc-bio` source. `plane_to_canonical_bytes` (`iscc_bio/imagewalk/common.py`)
+performs **no dtype canonicalization and no intensity rescaling** — it packs the raw dtype bytes as-is.
+The project's explicit aim is bit-for-bit identity with OMERO's own pixel representation
+(`calculate_pixel_sha1_bioio` in `iscc_bio/canonical.py` is built to match OMERO's server-side SHA1,
+and `scripts/imagewalk_check.py` verifies this).
+
+Consequences that constrain the design:
+
+- A uint16 image and its uint8 conversion produce **different** codes.
+- Selecting or reordering channels changes the plane sequence and therefore the code.
+- This pipeline's export is lossy: `img * 255/max` (`training_functions.py:920`, `:1025`) rescales
+  intensities and casts to uint8, and channels are restacked (`annotation_pipeline.py:1592`).
+
+Therefore **codes must be computed on raw source pixels, never on the exported training tiles.** This
+is not a limitation to work around — it is why the source-side code is canonical and directly
+comparable to what OMERO itself stores.
+
+## Scope decisions
+
+**What gets published:** original images + annotations describing which regions were annotated. The
+8-bit normalized tiles are *ephemeral working artifacts* for micro-SAM/CellPose and are never shipped.
+Hashing them would buy nothing, so we do not.
+
+**Two codes, both via `iscc-bio`:**
+
+| Field | Subject | Purpose |
+|---|---|---|
+| `source_iscc` | raw pixels of the source OMERO image | proves *which* images the annotations derive from |
+| `label_iscc` | the published annotation mask | proves the masks the recipient holds are the ones we made |
+
+**Region is already recorded.** The config already carries `is_patch`, `patch_x/y/width/height`,
+`z_slice`, `timepoint`, `channel`. So `source_iscc` plus those coordinates fully specifies lineage:
+*"this annotation came from the image with content-code X, region (x, y, w, h), at z/t/c."* Patches
+need no separate code.
+
+## Architecture
+
+### Component: `src/omero_annotate_ai/processing/provenance.py`
+
+A self-contained unit with no pipeline coupling. All ISCC logic lives here; every other touchpoint is
+a thin call into it.
+
+```
+iscc_available() -> bool
+    Guarded-import check for iscc-bio.
+
+compute_image_iscc(conn, image_id) -> Optional[str]
+    IMAGEWALK code over the raw OMERO pixels, via iscc-bio's OMERO/Blitz path.
+
+compute_file_iscc(path) -> Optional[str]
+    IMAGEWALK code for a local image file. Used for masks and for offline verification.
+
+compute_label_iscc(conn, label_id) -> Optional[str]
+    Masks are stored as OMERO file annotations (cf. ezomero.get_file_annotation,
+    training_functions.py:1094). Fetch, then delegate to compute_file_iscc.
+
+stamp_config(config, conn) -> AnnotationConfig
+    Fill source_iscc and label_iscc for every annotation. Caches per image_id and per
+    label_id — source images repeat across many annotation rows, so each is coded once.
+
+verify_config(config, conn=None, data_dir=None) -> ValidationResult
+    Recompute and diff against stored codes. Exactly one source must be given:
+      - conn:     re-fetch from OMERO and recompute (author-side check).
+      - data_dir: recompute from local image files (recipient-side, OFFLINE, no OMERO).
+    The offline mode is the one that delivers the stated goal, so it is not optional.
+    Three outcomes per entry: match / mismatch / missing. Reuses the existing
+    ValidationResult shape (annotation_config.py:1145).
+```
+
+The `data_dir` mode is what a third party actually runs: they hold the published images and the
+`config.yaml`, and nothing else. It maps each annotation's file to `compute_file_iscc` and compares
+against the stored `source_iscc` / `label_iscc`.
+
+### Schema changes: `src/omero_annotate_ai/core/annotation_config.py`
+
+- `ImageAnnotation` (`:58`): add `source_iscc: Optional[str] = None` and
+  `label_iscc: Optional[str] = None`.
+- Add a provenance toggle on the top-level `AnnotationConfig` (`:683`), not on `OMEROConfig` — it
+  governs package behaviour, not OMERO connection details: `iscc_mode: Literal["off", "on"] = "off"`.
+- Add both fields to the column lists in `to_dataframe()` (`:855-911`) and `from_dataframe()` (`:945`).
+- Bump `schema_version`; document the new fields in `get_config_template()` (`:1323`).
+
+### Storage: `config.yaml` is the provenance record
+
+Adding the fields to `ImageAnnotation` places them in two locations for free:
+
+- **`config.yaml`**, via `to_yaml()` (`:1037`) — the portable artifact that ships with the published
+  dataset. A recipient reads it offline, with no OMERO access, and re-verifies. This is the record
+  that matters.
+- **The OMERO tracking table**, via `to_dataframe()`/`from_dataframe()` — the server-side mirror,
+  obtained with no extra machinery.
+
+Both fields must be added to the string-column handling in `_prepare_dataframe_for_omero`
+(`omero_functions.py:311-337`) so they round-trip through `ezomero.post_table` / `get_table`.
+
+Size impact is negligible: the `annotations` list is already one entry per annotation; each gains
+roughly 80 characters.
+
+### Data flow — three paths, one implementation
+
+1. **Run path.** When `iscc_mode == "on"`, the pipeline calls `compute_image_iscc` once the
+   `image_id` is resolved (`annotation_pipeline.py:496`, `:853`) and `compute_label_iscc` once the
+   mask is uploaded and `label_id` is known. Codes persist through the existing
+   `sync_config_to_omero_table` path (`omero_functions.py:474`) and `save_yaml`. The hook is small
+   because the logic lives in the unit.
+
+2. **Retrofit path.** `stamp_config(config, conn)` fills codes into any *existing* `config.yaml` from
+   a past run. This matters: without it, every annotation set produced before this feature could
+   never be published with provenance.
+
+3. **Verify path.** `verify_config(config, conn)` recomputes and reports.
+
+## Dependencies
+
+`iscc-bio` is a proof of concept (v0.1.0; its own docs warn that "breaking changes may be released at
+any time") and pulls in `bioio`. It is therefore an **optional extra**, pinned tightly:
+
+```
+[project.optional-dependencies]
+provenance = ["iscc-bio>=0.1,<0.2"]
+```
+
+Codes are **always computed** via `iscc-bio`. We deliberately do not read codes that the server-side
+`omero-iscc` service may have attached: one code path is simpler, and it avoids depending on a
+namespace convention and on servers running that service. (Because `iscc-bio` matches OMERO
+bit-for-bit, a server-supplied code would agree with ours anyway — so nothing is lost.)
+
+This mirrors the existing `microsam` optional-group + guarded-import pattern already used in the
+package.
+
+## Error handling
+
+Provenance is **best-effort and must never fail an annotation run.**
+
+- `iscc-bio` not installed → `iscc_available()` is False, codes stay `None`, one clear warning, the
+  pipeline is otherwise unaffected.
+- `iscc_mode == "off"` (the default) → no computation and no import attempt; zero runtime cost and no
+  behaviour change for existing users.
+- An OMERO fetch or compute error on one image → that entry's code stays `None` with a warning; the
+  run continues.
+- `verify_config` distinguishes **missing** from **mismatch**. A `None` code is an absence of
+  evidence, not evidence of tampering, and must not be reported as a failure.
+
+## Testing
+
+Following the test-file mapping in `CLAUDE.md`:
+
+- **New `tests/test_provenance.py`** — mock `iscc_bio`. Cover: guarded-import graceful skip when the
+  library is absent; per-`image_id` and per-`label_id` caching (assert one call per unique id, not per
+  annotation row); `stamp_config` populates both fields; `verify_config` returns each of the three
+  states in **both** `conn` and `data_dir` modes; passing neither `conn` nor `data_dir` (or both) is
+  an error; a compute error on one image does not abort the pass.
+- **`tests/test_config.py`** — the new fields round-trip through YAML, JSON, and
+  `to_dataframe`/`from_dataframe`; `get_config_template()` stays valid.
+- **`tests/test_omero_functions.py`** — `_prepare_dataframe_for_omero` types the two new string
+  columns correctly.
+
+## Verification
+
+1. `pixi run -e dev pytest tests/ -v` — all pass, including the new provenance tests.
+2. With `iscc_mode="on"`: run against an OMERO image, confirm `source_iscc` appears in `config.yaml`
+   and in the tracking table, computed once per unique `image_id`.
+3. **The core claim.** Export a *lossless* copy of a source image in a different container format
+   (e.g. OME-TIFF → OME-Zarr) and confirm `compute_file_iscc(copy) == source_iscc`. This is the
+   format-independence that the whole design rests on.
+4. Alter the pixels of that copy; confirm `verify_config` reports **mismatch**. Clear a stored code;
+   confirm it reports **missing**, not mismatch.
+5. **Simulate the recipient.** With no OMERO connection at all, run
+   `verify_config(config, data_dir=...)` against the published images and `config.yaml` alone, and
+   confirm every entry reports **match**. This is the end-user story the feature exists for; if it
+   does not work offline, the feature has failed regardless of the other checks.
+6. Retrofit: take a `config.yaml` from a previous run with no codes, run `stamp_config`, confirm both
+   fields populate.
+7. Uninstall the `provenance` extra: confirm the pipeline still runs end to end, codes are `None`, and
+   exactly one warning is emitted.
+
+## Out of scope (YAGNI)
+
+- **`iscc-sum` / byte-level codes** — cannot compare across container formats; the wrong tool.
+- **Hashing the 8-bit training tiles** — ephemeral, never published.
+- **Reading codes from `omero-iscc`** — deliberately rejected in favour of a single compute path.
+- **Deduplication and train/val leakage detection** via ISCC similarity (Hamming distance).
+- **Drift monitoring** — detecting that an OMERO source image changed after annotation.
+
+Each is a plausible future extension; none is needed for publication-grade provenance, which is the
+goal here.
+
+## References
+
+- ISCC-BIO — https://bio.iscc.codes/ (IMAGEWALK spec; PoC v0.1.0)
+- `iscc-bio` source — https://github.com/bio-codes/iscc-bio (Apache-2.0)
+- `omero-iscc` — https://github.com/bio-codes/omero-iscc (server-side ISCC on import; not used here)
+- BIO-CODES project — https://bio-codes.io/
+- ISCC-SUM (evaluated and rejected for this use) — https://sum.iscc.codes/userguide/

--- a/docs/superpowers/specs/2026-07-13-iscc-provenance-design.md
+++ b/docs/superpowers/specs/2026-07-13-iscc-provenance-design.md
@@ -106,11 +106,15 @@ verify_config(config, conn=None, data_dir=None) -> ValidationResult
     The offline mode is the one that delivers the stated goal, so it is not optional.
     Three outcomes per entry: match / mismatch / missing. Reuses the existing
     ValidationResult shape (annotation_config.py:1145).
+    Raises RuntimeError (not a ValidationResult) if iscc-bio is not installed, in both
+    modes — see "Error handling" below for why this is intentionally NOT best-effort.
 ```
 
 The `data_dir` mode is what a third party actually runs: they hold the published images and the
-`config.yaml`, and nothing else. It maps each annotation's file to `compute_file_iscc` and compares
-against the stored `source_iscc` / `label_iscc`.
+`config.yaml`, and nothing else. It is **content-addressed**: every image file under the directory is
+coded, and each stored `source_iscc` / `label_iscc` must appear somewhere in that set. Filenames are
+never consulted, so renaming a published file does not break verification — which is exactly the
+property a content code is supposed to give us.
 
 ### Schema changes: `src/omero_annotate_ai/core/annotation_config.py`
 
@@ -171,16 +175,28 @@ package.
 
 ## Error handling
 
-Provenance is **best-effort and must never fail an annotation run.**
+Stamping and verifying have **deliberately asymmetric** failure behaviour when `iscc-bio` is missing:
 
-- `iscc-bio` not installed → `iscc_available()` is False, codes stay `None`, one clear warning, the
-  pipeline is otherwise unaffected.
+- **`stamp_config` is best-effort and silent.** `iscc-bio` not installed → `iscc_available()` is
+  False, codes stay `None`, one clear warning is logged, and the pipeline / annotation run is
+  otherwise unaffected. Stamping is a nice-to-have during a run, so losing it must never cost us the
+  annotations.
+- **`verify_config` refuses to run.** If `iscc-bio` is not installed, it **raises `RuntimeError`**
+  with an install hint — in both `conn` and `data_dir` modes — instead of returning a
+  `ValidationResult`. Verifying is the whole point of this feature: with the library absent, nothing
+  can actually be recomputed, so a returned "result" would be a verdict with nothing behind it. (An
+  earlier version of this code returned a result in that case and reported every image as a
+  *mismatch* — i.e. it accused good, untampered data of being tampered with. A verdict you cannot
+  back up is worse than no verdict, so this now raises instead.)
 - `iscc_mode == "off"` (the default) → no computation and no import attempt; zero runtime cost and no
-  behaviour change for existing users.
-- An OMERO fetch or compute error on one image → that entry's code stays `None` with a warning; the
-  run continues.
-- `verify_config` distinguishes **missing** from **mismatch**. A `None` code is an absence of
-  evidence, not evidence of tampering, and must not be reported as a failure.
+  behaviour change for existing users. This only affects the stamping hook; `verify_config` can still
+  be called directly regardless of `iscc_mode`.
+- An OMERO fetch or compute error on one image (library present, one code fails) → that entry's code
+  stays `None` with a warning; the run/verify continues.
+- `verify_config` distinguishes **missing** from **mismatch**. A `None` (or unmatched, in `data_dir`
+  mode) code is an absence of evidence, not evidence of tampering, and is reported as a warning, not
+  an error. In `data_dir` mode, a file that cannot be read is likewise a warning ("verification
+  incomplete"), never a mismatch.
 
 ## Testing
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -38,6 +38,13 @@ Our tutorials are designed to take you from beginner to advanced user:
 <p><a href="training-data-prep.md" class="md-button">View Tutorial</a></p>
 </div>
 
+<div class="tutorial-card">
+<h3>Content Provenance (ISCC)</h3>
+<span class="status-badge planned">Coming Soon</span>
+<p>Record ISO 24138 content codes so a published dataset can be verified offline.</p>
+<p><a href="provenance.md" class="md-button">View Tutorial</a></p>
+</div>
+
 ### 🧠 **Advanced Training**
 
 <div class="tutorial-card">

--- a/docs/tutorials/provenance.md
+++ b/docs/tutorials/provenance.md
@@ -64,6 +64,13 @@ Stamping happens once processing is complete (masks already uploaded), and just 
 the config is persisted, so the codes land in both `config.yaml` and the OMERO tracking
 table.
 
+!!! warning "CellPose preparation is not stamped automatically"
+
+    `run_cellpose_preparation()` does not route through the pipeline's finalization
+    step, so `iscc_mode: "on"` has no effect there. Stamp those datasets explicitly
+    with `stamp_config(config, conn)` — see
+    [Retroactively stamp an old config](#2-retroactively-stamp-an-old-config) below.
+
 ## 2. Retroactively stamp an old config
 
 `stamp_config` is idempotent, so it can be pointed at a `config.yaml` from a run that

--- a/docs/tutorials/provenance.md
+++ b/docs/tutorials/provenance.md
@@ -1,0 +1,154 @@
+# Tutorial: Content Provenance (ISCC)
+
+When you publish an annotation dataset, how does anyone downstream know the images and
+masks they received are the ones the config actually describes — without trusting you,
+and without an OMERO connection?
+
+OMERO Annotate AI can record [ISO 24138](https://www.iso.org/standard/77899.html)
+content-provenance codes ("ISCC") for every annotation. A code is a hash-like fingerprint
+of an image's raw pixels. Anyone holding the published files and the `config.yaml` can
+recompute the codes themselves and confirm the data matches — fully offline, no server,
+no trust required.
+
+## Prerequisites
+
+!!! note "Install the provenance extra"
+    ```bash
+    pip install 'omero-annotate-ai[provenance]'
+    ```
+    This installs `iscc-bio`, pinned to `>=0.1,<0.2`. Without it, stamping is silently
+    skipped (codes stay `null`) and verification refuses to run — see
+    [Error handling](#error-handling) below.
+
+## The one thing to understand first
+
+**Codes are computed on raw source pixels only** — never on the exported 8-bit training
+tiles.
+
+The ISCC algorithm used here (IMAGEWALK) is an *exact* code: it packs raw dtype bytes
+with no bit-depth or intensity canonicalization, matching OMERO's own pixel
+representation bit-for-bit. That gives it a useful property and a sharp limitation:
+
+- It **survives a change of container format** — the same image exported as OME-TIFF,
+  OME-Zarr, or read back from OMERO all produce the same code.
+- It does **not** survive a change of pixel values. The training-tile export path
+  rescales intensities (`img * 255/max`) and restacks channels, so a tile's code will
+  **never** match its source image's code. Provenance is about the source image and the
+  annotation mask, not the derived training crop.
+
+## 1. Enable stamping during a run
+
+Set `iscc_mode: "on"` (default is `"off"`) before running the pipeline:
+
+```yaml
+# config.yaml
+iscc_mode: "on"
+```
+
+```python
+config.iscc_mode = "on"
+pipeline = create_pipeline(config, conn)
+pipeline.run_microsam_annotation()
+```
+
+After the run, each annotation in `config.yaml` carries its codes:
+
+```yaml
+annotations:
+  - image_id: 101
+    source_iscc: "ISCC:..."   # source image's raw OMERO pixels
+    label_iscc: "ISCC:..."    # annotation mask
+```
+
+Stamping happens once processing is complete (masks already uploaded), and just before
+the config is persisted, so the codes land in both `config.yaml` and the OMERO tracking
+table.
+
+## 2. Retroactively stamp an old config
+
+`stamp_config` is idempotent, so it can be pointed at a `config.yaml` from a run that
+predates this feature (or one where `iscc_mode` was left `"off"`):
+
+```python
+from omero_annotate_ai.core.annotation_config import load_config
+from omero_annotate_ai.processing.provenance import stamp_config
+
+config = load_config("config.yaml")
+stamp_config(config, conn)
+config.save_yaml("config.yaml")
+```
+
+Codes that are already present are left alone, and each unique `image_id` / `label_id`
+is coded once and cached — a source image shared by many patches or z-slices is not
+re-coded per row.
+
+`stamp_config` is **best-effort**: if `iscc-bio` is not installed, or a particular image
+can't be coded, it logs a warning and leaves that field `None`. It never raises, so
+running it never costs you the underlying annotation data.
+
+## 3. Verify as the author (online)
+
+With a live OMERO connection, recompute each stored code from the server and compare:
+
+```python
+from omero_annotate_ai.processing.provenance import verify_config
+
+result = verify_config(config, conn=conn)
+print(result.summary)
+print(result.is_valid)
+```
+
+## 4. Verify as a recipient (fully offline)
+
+This is the scenario the feature exists for: a third party has the published images and
+`config.yaml`, nothing else — no OMERO, no network.
+
+```python
+result = verify_config(config, data_dir="published_dataset/")
+print(result.summary)
+```
+
+Offline verification is **content-addressed, not filename-addressed**. Every image file
+under `data_dir` is coded (`.zarr` stores are matched as directories, not by their
+internal chunk files), and each stored `source_iscc` / `label_iscc` only needs to appear
+*somewhere* in that set. Filenames are never consulted — renaming a published file does
+not break verification.
+
+## Understanding the result: three outcomes
+
+`verify_config` returns a `ValidationResult` with `is_valid`, `errors`, and `warnings`:
+
+| Outcome | Meaning | Effect |
+|---|---|---|
+| **Match** | A file in `data_dir` (or OMERO) codes to the stored value | Nothing reported |
+| **Mismatch** | A code is stored, but no file in the data matches it | **Error** — `is_valid` becomes `False` |
+| **Missing** | The annotation was never stamped (`source_iscc`/`label_iscc` is `null`) | **Warning** — `is_valid` stays `True` |
+
+A file that exists but can't be read (corrupt, permission error, unsupported format)
+also produces a warning — "verification incomplete" — never a mismatch. Absence of
+evidence is not evidence of tampering: only a code that is present and *disagrees* with
+the data counts as a real mismatch.
+
+## Error handling
+
+`stamp_config` and `verify_config` are deliberately asymmetric:
+
+- **`stamp_config` is best-effort and silent.** No `iscc-bio`, or a failure computing a
+  particular code, means the field stays `None` and one warning is logged. An annotation
+  run is never harmed by provenance failing — stamping is a nice-to-have.
+- **`verify_config` raises `RuntimeError` if `iscc-bio` is not installed — in both `conn`
+  and `data_dir` modes.** It does not return a result. With no library, nothing can
+  actually be recomputed, so any verdict (green or red) would be reporting a check that
+  never happened. Verifying is the whole point of this feature, so a bogus verdict —
+  such as an early version of this code that reported every image as a *mismatch* simply
+  because it couldn't check anything — is unacceptable.
+
+`verify_config` also requires **exactly one** of `conn` / `data_dir`; passing neither or
+both raises `ValueError`.
+
+## Next steps
+
+- [Configuration Guide](../configuration.md#content-provenance-iscc) — `iscc_mode` and
+  the `source_iscc` / `label_iscc` schema fields
+- [Installation Guide](../installation.md#optional-content-provenance-iscc) — installing
+  the `provenance` extra

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,11 @@ edit_uri: edit/main/docs/
 # Fail the build on any warning
 strict: false
 
+# Internal planning/spec artifacts (committed history, read by other tooling)
+# must not be published as orphan public pages on the docs site.
+exclude_docs: |
+  superpowers/
+
 theme:
   name: material
   language: en

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
     - Cellpose Integration: tutorials/cellpose-integration.md
     - Training Data Prep: tutorials/training-data-prep.md
     - BiaPy Integration: tutorials/biapy-integration.md
+    - Content Provenance (ISCC): tutorials/provenance.md
   - API Reference: api/
 
 plugins:

--- a/pixi.lock
+++ b/pixi.lock
@@ -27050,6 +27050,7 @@ packages:
   - marimo>=0.19.2,<0.20 ; extra == 'notebooks'
   - keyring>=23.0.0 ; extra == 'notebooks'
   - napari>=0.4.15 ; extra == 'microsam'
+  - iscc-bio>=0.1,<0.2 ; extra == 'provenance'
   - pytest>=6.0 ; extra == 'dev'
   - pytest-cov>=2.0 ; extra == 'dev'
   - black>=22.0 ; extra == 'dev'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,12 @@ microsam = [
     "napari>=0.4.15",
     # Note: micro-sam is conda-only, install with: conda install -c conda-forge micro-sam
 ]
+provenance = [
+    # ISO 24138 pixel-content codes for dataset provenance.
+    # Pinned tightly: iscc-bio is a proof of concept and declares that breaking
+    # changes may be released at any time.
+    "iscc-bio>=0.1,<0.2",
+]
 dev = [
     "pytest>=6.0",
     "pytest-cov>=2.0",

--- a/src/omero_annotate_ai/core/annotation_config.py
+++ b/src/omero_annotate_ai/core/annotation_config.py
@@ -110,6 +110,16 @@ class ImageAnnotation(BaseModel):
         default=None, description="OMERO schema attachment ID"
     )
 
+    # ISCC content provenance (None until stamped; see processing/provenance.py)
+    source_iscc: Optional[str] = Field(
+        default=None,
+        description="ISO 24138 content code of the source image's raw OMERO pixels",
+    )
+    label_iscc: Optional[str] = Field(
+        default=None,
+        description="ISO 24138 content code of the annotation mask",
+    )
+
     # Channel presentation (how the image was displayed during annotation)
     channel_presentation: Optional[List[ChannelPresentation]] = Field(
         default=None,
@@ -685,7 +695,7 @@ class AnnotationConfig(BaseModel):
 
     # Schema identification
     schema_version: str = Field(
-        default="2.0.0", description="Configuration schema version"
+        default="2.1.0", description="Configuration schema version"
     )
 
     # Config file tracking for persistence
@@ -745,6 +755,13 @@ class AnnotationConfig(BaseModel):
     feature_types: List[FeatureType] = Field(
         default_factory=list,
         description="Annotation classes (e.g. cell, nucleus) with display colors",
+    )
+
+    # ISCC content provenance (ISO 24138)
+    iscc_mode: Literal["off", "on"] = Field(
+        default="off",
+        description="Compute ISCC content provenance during a run. Requires the "
+        "'provenance' extra. Off by default: adds per-image compute cost.",
     )
 
     def model_dump(self, **kwargs):
@@ -879,6 +896,8 @@ class AnnotationConfig(BaseModel):
                 "z_start": annotation.z_start,
                 "z_end": annotation.z_end,
                 "z_length": annotation.z_length,
+                "source_iscc": annotation.source_iscc or "None",
+                "label_iscc": annotation.label_iscc or "None",
             }
             rows.append(row)
 
@@ -908,6 +927,8 @@ class AnnotationConfig(BaseModel):
             "z_start",
             "z_end",
             "z_length",
+            "source_iscc",
+            "label_iscc",
         ]
 
         df = pd.DataFrame(rows, columns=columns)
@@ -1001,6 +1022,15 @@ class AnnotationConfig(BaseModel):
             updated_at_str = str(row.get("annotation_updated_at", "None"))
             if updated_at_str != "None":
                 annotation_data["annotation_updated_at"] = updated_at_str
+
+            # ISCC provenance codes - "None" sentinel means not yet stamped
+            source_iscc_str = str(row.get("source_iscc", "None"))
+            if source_iscc_str != "None":
+                annotation_data["source_iscc"] = source_iscc_str
+
+            label_iscc_str = str(row.get("label_iscc", "None"))
+            if label_iscc_str != "None":
+                annotation_data["label_iscc"] = label_iscc_str
 
             self.add_annotation(ImageAnnotation(**annotation_data))
 
@@ -1324,7 +1354,7 @@ def get_config_template() -> str:
     """Get a YAML template with comments for all configuration options."""
     template = """# OMERO micro-SAM Configuration Template v2.0.0
 
-schema_version: "2.0.0"
+schema_version: "2.1.0"
 
 name: "micro_sam_nuclei_segmentation"
 version: "1.0.0"
@@ -1396,6 +1426,12 @@ ai_model:
 
 output:
   output_directory: "./annotations"
+
+# ISCC content provenance (ISO 24138). Requires: pip install 'omero-annotate-ai[provenance]'
+# When "on", each annotation records the content code of its source image
+# (source_iscc) and mask (label_iscc), so a published dataset can be verified
+# offline. Off by default.
+iscc_mode: off
 
 tags: ["segmentation", "nuclei", "micro-sam", "AI-ready"]
 """

--- a/src/omero_annotate_ai/core/annotation_config.py
+++ b/src/omero_annotate_ai/core/annotation_config.py
@@ -1183,7 +1183,13 @@ class ValidationResult(BaseModel):
     @property
     def summary(self) -> str:
         if self.is_valid:
-            return f"OK: {self.annotation_count} annotations are consistent with config"
+            base = f"OK: {self.annotation_count} annotations are consistent with config"
+            # Warnings must surface even when valid. An unstamped dataset is valid
+            # (absence of evidence is not evidence of tampering) but a bare "OK"
+            # would hide that nothing was actually verified.
+            if self.warnings:
+                return f"{base} ({len(self.warnings)} warning(s))"
+            return base
         parts = []
         if self.errors:
             parts.append(f"{len(self.errors)} error(s)")
@@ -1352,7 +1358,7 @@ def create_default_config() -> AnnotationConfig:
 
 def get_config_template() -> str:
     """Get a YAML template with comments for all configuration options."""
-    template = """# OMERO micro-SAM Configuration Template v2.0.0
+    template = """# OMERO micro-SAM Configuration Template v2.1.0
 
 schema_version: "2.1.0"
 
@@ -1431,7 +1437,7 @@ output:
 # When "on", each annotation records the content code of its source image
 # (source_iscc) and mask (label_iscc), so a published dataset can be verified
 # offline. Off by default.
-iscc_mode: off
+iscc_mode: "off"
 
 tags: ["segmentation", "nuclei", "micro-sam", "AI-ready"]
 """

--- a/src/omero_annotate_ai/core/annotation_pipeline.py
+++ b/src/omero_annotate_ai/core/annotation_pipeline.py
@@ -45,6 +45,7 @@ from ..omero.omero_functions import (
 )
 from ..omero.omero_utils import get_dask_image_single, get_table_by_name
 from ..processing.image_functions import generate_patch_coordinates
+from ..processing.provenance import stamp_config
 
 
 class AnnotationPipeline:
@@ -1479,12 +1480,31 @@ class AnnotationPipeline:
         
         return processed_count
 
+    def _stamp_provenance(self) -> None:
+        """Record ISCC content provenance for the annotated images and masks.
+
+        No-op unless config.iscc_mode == "on". Best-effort: provenance is a
+        publication concern, and losing it must never cost us the annotations,
+        so any failure is logged and swallowed.
+        """
+        if self.config.iscc_mode != "on":
+            return
+
+        try:
+            stamp_config(self.config, self.conn)
+        except Exception as exc:
+            print(f"⚠️ Could not stamp ISCC provenance: {exc}")
+
     def _finalize_workflow(self, processed_count: int) -> None:
         """Finalize the workflow with cleanup and uploads.
-        
+
         Args:
             processed_count: Number of units that were processed
         """
+        # Stamp ISCC provenance before the config is persisted, so the codes
+        # travel into both config.yaml and the OMERO tracking table.
+        self._stamp_provenance()
+
         # Final config save
         self._auto_save_config()
 

--- a/src/omero_annotate_ai/core/annotation_pipeline.py
+++ b/src/omero_annotate_ai/core/annotation_pipeline.py
@@ -1505,6 +1505,19 @@ class AnnotationPipeline:
         # travel into both config.yaml and the OMERO tracking table.
         self._stamp_provenance()
 
+        # The tracking table was last written inside the batch loop, before
+        # provenance was stamped, so it still has code-less source_iscc/
+        # label_iscc columns. Rewrite it now so the codes actually reach the
+        # table - otherwise they only ever live in config.yaml, and a later
+        # resume (which rebuilds config.annotations FROM the table) would
+        # silently wipe them back out. Provenance must never harm an
+        # annotation run, so a failure here is logged and swallowed.
+        if self.config.iscc_mode == "on" and not self.config.workflow.read_only_mode:
+            try:
+                self._replace_omero_table_from_config()
+            except Exception as exc:
+                print(f"⚠️ Could not write ISCC provenance to OMERO table: {exc}")
+
         # Final config save
         self._auto_save_config()
 

--- a/src/omero_annotate_ai/omero/omero_functions.py
+++ b/src/omero_annotate_ai/omero/omero_functions.py
@@ -336,6 +336,11 @@ def _prepare_dataframe_for_omero(df: pd.DataFrame) -> pd.DataFrame:
         if col in df.columns:
             df[col] = df[col].fillna("None").astype(str)
 
+    iscc_columns = ["source_iscc", "label_iscc"]
+    for col in iscc_columns:
+        if col in df.columns:
+            df[col] = df[col].fillna("None").astype(str)
+
     return df
 
 

--- a/src/omero_annotate_ai/processing/provenance.py
+++ b/src/omero_annotate_ai/processing/provenance.py
@@ -97,9 +97,9 @@ def compute_label_iscc(conn, label_id: int) -> Optional[str]:
         logger.warning(_MISSING_MSG)
         return None
 
-    import ezomero
-
     try:
+        import ezomero
+
         with tempfile.TemporaryDirectory() as tmp_dir:
             mask_path = ezomero.get_file_annotation(
                 conn, int(label_id), folder_path=tmp_dir
@@ -245,10 +245,14 @@ def verify_config(config, conn=None, data_dir=None):
         is a warning, because absence of evidence is not evidence of tampering.
 
     Raises:
-        ValueError: if not exactly one of conn/data_dir is given.
+        ValueError: if not exactly one of conn/data_dir is given, or if
+            data_dir does not exist or is not a directory.
         RuntimeError: if iscc-bio is not installed. Without it, nothing can
             actually be recomputed, so returning a verdict (green or red)
-            would be reporting a check that never happened.
+            would be reporting a check that never happened. Also raised if
+            data_dir mode finds nothing codeable at all (no codes, no failed
+            paths) - refusing to return a verdict is safer than returning a
+            false "tampered" one.
     """
     from ..core.annotation_config import ValidationIssue, ValidationResult
 
@@ -268,7 +272,38 @@ def verify_config(config, conn=None, data_dir=None):
     warnings = []
 
     if data_dir is not None:
-        available_codes, failed_paths = _scan_directory_codes(data_dir)
+        data_dir_path = Path(data_dir)
+        if not data_dir_path.is_dir():
+            raise ValueError(
+                f"data_dir does not exist or is not a directory: {data_dir_path}"
+            )
+
+        if data_dir_path.suffix.lower() in _IMAGE_DIR_SUFFIXES:
+            # data_dir IS the .zarr store root itself, not a parent folder
+            # containing it. Code it directly as a single store - do not
+            # walk into it looking for children, and do not treat it as an
+            # ordinary directory to scan (that would find nothing, since a
+            # zarr store's internal chunk files don't match any recognised
+            # image suffix).
+            code = compute_file_iscc(data_dir_path)
+            if code is not None:
+                available_codes, failed_paths = {code}, []
+            else:
+                available_codes, failed_paths = set(), [data_dir_path]
+        else:
+            available_codes, failed_paths = _scan_directory_codes(data_dir_path)
+
+        if not available_codes and not failed_paths:
+            # Nothing codeable was found at all: wrong path, empty directory,
+            # or no recognised image suffixes present. Every stored code
+            # would otherwise fall through to the "not in available_codes"
+            # branch below and be reported as a mismatch - a false tampering
+            # verdict for perfectly good data. Refuse to verify instead.
+            raise RuntimeError(
+                f"No image data could be coded under {data_dir_path}; "
+                "cannot verify."
+            )
+
         for path in failed_paths:
             warnings.append(
                 ValidationIssue(

--- a/src/omero_annotate_ai/processing/provenance.py
+++ b/src/omero_annotate_ai/processing/provenance.py
@@ -1,0 +1,112 @@
+"""ISCC content provenance for published annotation datasets.
+
+Computes ISO 24138:2024 content codes via iscc-bio's IMAGEWALK traversal.
+
+IMAGEWALK is an *exact* code: it packs raw dtype bytes with no bit-depth or
+intensity canonicalization, aiming for bit-for-bit identity with OMERO's own
+pixel representation. It therefore survives a change of container format
+(OME-TIFF / OME-Zarr / OMERO) but NOT a change of pixel values.
+
+Consequence: codes are computed on raw source pixels only. The exported 8-bit
+training tiles are rescaled (img * 255/max) and channel-restacked, so their
+codes would not match the source, and they are never coded here.
+
+iscc-bio is an optional dependency and is imported lazily. Everything in this
+module degrades to None with a warning when it is absent.
+"""
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+_MISSING_MSG = (
+    "iscc-bio is not installed; skipping ISCC provenance. "
+    "Install it with: pip install 'omero-annotate-ai[provenance]'"
+)
+
+
+def _get_biocode():
+    """Return iscc_bio.api.biocode, or None if iscc-bio is not installed."""
+    try:
+        from iscc_bio.api import biocode
+    except ImportError:
+        return None
+    return biocode
+
+
+def iscc_available() -> bool:
+    """Whether iscc-bio is importable and provenance can be computed."""
+    return _get_biocode() is not None
+
+
+def _first_code(results: Optional[List[Dict[str, Any]]]) -> Optional[str]:
+    """Take the ISCC of the first scene.
+
+    biocode() returns one entry per scene. OMERO images and the exported masks
+    are single-scene, so the first entry is the one we want.
+    """
+    if not results:
+        return None
+    return results[0].get("iscc_code")
+
+
+def compute_file_iscc(path: Union[str, Path]) -> Optional[str]:
+    """Content code for a local image file. Returns None on any failure."""
+    biocode = _get_biocode()
+    if biocode is None:
+        logger.warning(_MISSING_MSG)
+        return None
+
+    try:
+        return _first_code(biocode(source=str(path)))
+    except Exception as exc:  # provenance is best-effort, never fatal
+        logger.warning(f"Could not compute ISCC for file {path}: {exc}")
+        return None
+
+
+def compute_image_iscc(conn, image_id: int) -> Optional[str]:
+    """Content code for an OMERO image, from its raw pixels.
+
+    This is the canonical source-side code: iscc-bio reads OMERO's pixel data
+    directly, so it is directly comparable to any faithful copy of the image.
+    """
+    biocode = _get_biocode()
+    if biocode is None:
+        logger.warning(_MISSING_MSG)
+        return None
+
+    try:
+        return _first_code(biocode(conn=conn, iid=int(image_id)))
+    except Exception as exc:
+        logger.warning(f"Could not compute ISCC for OMERO image {image_id}: {exc}")
+        return None
+
+
+def compute_label_iscc(conn, label_id: int) -> Optional[str]:
+    """Content code for an annotation mask.
+
+    Masks are stored as OMERO file annotations, so this downloads the mask to a
+    temporary directory and codes it as a file.
+    """
+    biocode = _get_biocode()
+    if biocode is None:
+        logger.warning(_MISSING_MSG)
+        return None
+
+    import ezomero
+
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mask_path = ezomero.get_file_annotation(
+                conn, int(label_id), folder_path=tmp_dir
+            )
+            if mask_path is None:
+                logger.warning(f"Label file annotation {label_id} could not be fetched")
+                return None
+            return compute_file_iscc(mask_path)
+    except Exception as exc:
+        logger.warning(f"Could not compute ISCC for label {label_id}: {exc}")
+        return None

--- a/src/omero_annotate_ai/processing/provenance.py
+++ b/src/omero_annotate_ai/processing/provenance.py
@@ -110,3 +110,49 @@ def compute_label_iscc(conn, label_id: int) -> Optional[str]:
     except Exception as exc:
         logger.warning(f"Could not compute ISCC for label {label_id}: {exc}")
         return None
+
+
+def stamp_config(config, conn):
+    """Fill in source_iscc and label_iscc for every annotation in the config.
+
+    Safe to re-run: codes that are already present are left alone, so this can
+    be pointed at an existing config.yaml from a previous run to add provenance
+    retroactively.
+
+    Each unique image_id and label_id is coded once and cached - a source image
+    is typically shared by many annotation rows (patches, z-slices, timepoints),
+    and coding it per row would be wasteful.
+
+    Args:
+        config: AnnotationConfig to stamp, mutated in place.
+        conn: OMERO BlitzGateway connection.
+
+    Returns:
+        The same config, for chaining.
+    """
+    if not iscc_available():
+        logger.warning(_MISSING_MSG)
+        return config
+
+    image_cache: Dict[int, Optional[str]] = {}
+    label_cache: Dict[int, Optional[str]] = {}
+
+    for annotation in config.annotations:
+        if annotation.source_iscc is None:
+            image_id = annotation.image_id
+            if image_id not in image_cache:
+                image_cache[image_id] = compute_image_iscc(conn, image_id)
+            annotation.source_iscc = image_cache[image_id]
+
+        if annotation.label_iscc is None and annotation.label_id is not None:
+            label_id = annotation.label_id
+            if label_id not in label_cache:
+                label_cache[label_id] = compute_label_iscc(conn, label_id)
+            annotation.label_iscc = label_cache[label_id]
+
+    coded = sum(1 for a in config.annotations if a.source_iscc is not None)
+    logger.info(
+        f"Stamped ISCC provenance: {coded}/{len(config.annotations)} annotations, "
+        f"{len(image_cache)} unique source image(s)"
+    )
+    return config

--- a/src/omero_annotate_ai/processing/provenance.py
+++ b/src/omero_annotate_ai/processing/provenance.py
@@ -156,3 +156,141 @@ def stamp_config(config, conn):
         f"{len(image_cache)} unique source image(s)"
     )
     return config
+
+
+# Image formats iscc-bio can read, used when scanning a published data directory.
+_IMAGE_SUFFIXES = {".tif", ".tiff", ".czi", ".nd2", ".lif", ".dv", ".zarr"}
+
+
+def _scan_directory_codes(data_dir: Union[str, Path]) -> set:
+    """Content-code every image file under data_dir.
+
+    Returns a set of codes, deliberately discarding filenames: verification is
+    content-addressed, so renaming a published file must not break it.
+    """
+    codes = set()
+    for path in sorted(Path(data_dir).rglob("*")):
+        if path.is_file() and path.suffix.lower() in _IMAGE_SUFFIXES:
+            code = compute_file_iscc(path)
+            if code is not None:
+                codes.add(code)
+    return codes
+
+
+def verify_config(config, conn=None, data_dir=None):
+    """Verify the ISCC codes stored in a config against actual data.
+
+    Exactly one source must be given:
+      conn:     recompute from OMERO. The author's check against the live server.
+      data_dir: recompute from local files, fully OFFLINE, no OMERO needed. This
+                is what a recipient of a published dataset runs, and it is the
+                reason this feature exists.
+
+    In data_dir mode the check is content-addressed: every image file under the
+    directory is coded, and each stored code must appear somewhere in that set.
+    Filenames are irrelevant.
+
+    Args:
+        config: AnnotationConfig carrying stamped codes.
+        conn: OMERO BlitzGateway, for the online check.
+        data_dir: Directory of published image files, for the offline check.
+
+    Returns:
+        ValidationResult. A mismatch is an error; a code that was never stamped
+        is a warning, because absence of evidence is not evidence of tampering.
+    """
+    from ..core.annotation_config import ValidationIssue, ValidationResult
+
+    if (conn is None) == (data_dir is None):
+        raise ValueError(
+            "verify_config requires exactly one of 'conn' (verify against OMERO) "
+            "or 'data_dir' (verify offline against published files)"
+        )
+
+    errors = []
+    warnings = []
+
+    available_codes = _scan_directory_codes(data_dir) if data_dir is not None else None
+    image_cache: Dict[int, Optional[str]] = {}
+    label_cache: Dict[int, Optional[str]] = {}
+
+    for annotation in config.annotations:
+        label = f"image {annotation.image_id} ({annotation.image_name})"
+
+        # --- source image ---
+        if annotation.source_iscc is None:
+            warnings.append(
+                ValidationIssue(
+                    field="source_iscc",
+                    message=f"No source ISCC stored for {label}; not verifiable. "
+                    "Run stamp_config() to add provenance.",
+                )
+            )
+        elif available_codes is not None:
+            if annotation.source_iscc not in available_codes:
+                errors.append(
+                    ValidationIssue(
+                        field="source_iscc",
+                        message=f"No file in the data directory matches the recorded "
+                        f"source ISCC for {label}. The data does not match the config.",
+                    )
+                )
+        else:
+            image_id = annotation.image_id
+            if image_id not in image_cache:
+                image_cache[image_id] = compute_image_iscc(conn, image_id)
+            actual = image_cache[image_id]
+            if actual is not None and actual != annotation.source_iscc:
+                errors.append(
+                    ValidationIssue(
+                        field="source_iscc",
+                        message=f"Source ISCC mismatch for {label}: config records "
+                        f"{annotation.source_iscc}, OMERO now yields {actual}.",
+                    )
+                )
+
+        # --- annotation mask ---
+        # A missing label_id means no mask was ever uploaded for this
+        # annotation, so there is nothing to verify or warn about. A missing
+        # label_iscc with a label_id present is the real "missing evidence"
+        # case. Note: verification itself keys off label_iscc, not label_id -
+        # data_dir mode never needs label_id at all.
+        if annotation.label_iscc is None:
+            if annotation.label_id is not None:
+                warnings.append(
+                    ValidationIssue(
+                        field="label_iscc",
+                        message=f"No label ISCC stored for {label}; mask not verifiable.",
+                    )
+                )
+            continue
+
+        if available_codes is not None:
+            if annotation.label_iscc not in available_codes:
+                errors.append(
+                    ValidationIssue(
+                        field="label_iscc",
+                        message=f"No file in the data directory matches the recorded "
+                        f"label ISCC for {label}. The mask does not match the config.",
+                    )
+                )
+        elif annotation.label_id is not None:
+            label_id = annotation.label_id
+            if label_id not in label_cache:
+                label_cache[label_id] = compute_label_iscc(conn, label_id)
+            actual = label_cache[label_id]
+            if actual is not None and actual != annotation.label_iscc:
+                errors.append(
+                    ValidationIssue(
+                        field="label_iscc",
+                        message=f"Label ISCC mismatch for {label}: config records "
+                        f"{annotation.label_iscc}, OMERO now yields {actual}.",
+                    )
+                )
+
+    return ValidationResult(
+        is_valid=len(errors) == 0,
+        errors=errors,
+        warnings=warnings,
+        annotation_count=len(config.annotations),
+    )

--- a/src/omero_annotate_ai/processing/provenance.py
+++ b/src/omero_annotate_ai/processing/provenance.py
@@ -16,9 +16,10 @@ module degrades to None with a warning when it is absent.
 """
 
 import logging
+import os
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
@@ -159,22 +160,66 @@ def stamp_config(config, conn):
 
 
 # Image formats iscc-bio can read, used when scanning a published data directory.
-_IMAGE_SUFFIXES = {".tif", ".tiff", ".czi", ".nd2", ".lif", ".dv", ".zarr"}
+# Plain files are matched by suffix directly. OME-Zarr stores are DIRECTORIES,
+# not files, so they need their own set and their own matching logic (see
+# _scan_directory_codes) - a ".zarr" suffix can never match `path.is_file()`.
+_IMAGE_FILE_SUFFIXES = {".tif", ".tiff", ".czi", ".nd2", ".lif", ".dv"}
+_IMAGE_DIR_SUFFIXES = {".zarr"}
 
 
-def _scan_directory_codes(data_dir: Union[str, Path]) -> set:
-    """Content-code every image file under data_dir.
+def _scan_directory_codes(
+    data_dir: Union[str, Path],
+) -> Tuple[Set[str], List[Path]]:
+    """Content-code every image file (and OME-Zarr store) under data_dir.
 
-    Returns a set of codes, deliberately discarding filenames: verification is
-    content-addressed, so renaming a published file must not break it.
+    Returns (codes, failed_paths):
+      codes:        set of ISCC codes found. Filenames are deliberately
+                    discarded - verification is content-addressed, so renaming
+                    a published file must not break it.
+      failed_paths: paths that matched an image suffix but could not be coded
+                    (unreadable/corrupt/permission error). The caller must
+                    surface these separately from "no match" - a file we
+                    could not read is not evidence that the data disagrees
+                    with the config.
+
+    Uses os.walk (not Path.rglob) so that once a directory is recognized as an
+    OME-Zarr store it can be pruned from further traversal: a zarr store can
+    contain tens of thousands of chunk files, and walking them all would be
+    pointless since the store is coded as a single unit.
     """
-    codes = set()
-    for path in sorted(Path(data_dir).rglob("*")):
-        if path.is_file() and path.suffix.lower() in _IMAGE_SUFFIXES:
-            code = compute_file_iscc(path)
-            if code is not None:
-                codes.add(code)
-    return codes
+    codes: Set[str] = set()
+    failed: List[Path] = []
+
+    for dirpath, dirnames, filenames in os.walk(data_dir):
+        dirpath_obj = Path(dirpath)
+
+        # Detect and code directory-shaped image stores (e.g. .zarr) among the
+        # immediate subdirectories, then prune them so os.walk does not
+        # descend into their internal chunk files.
+        remaining_dirnames = []
+        for dirname in sorted(dirnames):
+            if Path(dirname).suffix.lower() in _IMAGE_DIR_SUFFIXES:
+                dir_path = dirpath_obj / dirname
+                code = compute_file_iscc(dir_path)
+                if code is not None:
+                    codes.add(code)
+                else:
+                    failed.append(dir_path)
+                # Do not add to remaining_dirnames -> pruned from the walk.
+            else:
+                remaining_dirnames.append(dirname)
+        dirnames[:] = remaining_dirnames
+
+        for filename in sorted(filenames):
+            if Path(filename).suffix.lower() in _IMAGE_FILE_SUFFIXES:
+                file_path = dirpath_obj / filename
+                code = compute_file_iscc(file_path)
+                if code is not None:
+                    codes.add(code)
+                else:
+                    failed.append(file_path)
+
+    return codes, failed
 
 
 def verify_config(config, conn=None, data_dir=None):
@@ -198,6 +243,12 @@ def verify_config(config, conn=None, data_dir=None):
     Returns:
         ValidationResult. A mismatch is an error; a code that was never stamped
         is a warning, because absence of evidence is not evidence of tampering.
+
+    Raises:
+        ValueError: if not exactly one of conn/data_dir is given.
+        RuntimeError: if iscc-bio is not installed. Without it, nothing can
+            actually be recomputed, so returning a verdict (green or red)
+            would be reporting a check that never happened.
     """
     from ..core.annotation_config import ValidationIssue, ValidationResult
 
@@ -207,22 +258,39 @@ def verify_config(config, conn=None, data_dir=None):
             "or 'data_dir' (verify offline against published files)"
         )
 
+    if not iscc_available():
+        raise RuntimeError(
+            "Cannot verify ISCC provenance: iscc-bio is not installed. "
+            "Install it with: pip install 'omero-annotate-ai[provenance]'"
+        )
+
     errors = []
     warnings = []
 
-    available_codes = _scan_directory_codes(data_dir) if data_dir is not None else None
-    image_cache: Dict[int, Optional[str]] = {}
-    label_cache: Dict[int, Optional[str]] = {}
+    if data_dir is not None:
+        available_codes, failed_paths = _scan_directory_codes(data_dir)
+        for path in failed_paths:
+            warnings.append(
+                ValidationIssue(
+                    field="data_dir",
+                    message=f"Could not compute an ISCC for {path}; verification "
+                    "may be incomplete because this file could not be read.",
+                )
+            )
+    else:
+        available_codes = None
+        image_cache: Dict[int, Optional[str]] = {}
+        label_cache: Dict[int, Optional[str]] = {}
 
     for annotation in config.annotations:
-        label = f"image {annotation.image_id} ({annotation.image_name})"
+        desc = f"image {annotation.image_id} ({annotation.image_name})"
 
         # --- source image ---
         if annotation.source_iscc is None:
             warnings.append(
                 ValidationIssue(
                     field="source_iscc",
-                    message=f"No source ISCC stored for {label}; not verifiable. "
+                    message=f"No source ISCC stored for {desc}; not verifiable. "
                     "Run stamp_config() to add provenance.",
                 )
             )
@@ -232,7 +300,7 @@ def verify_config(config, conn=None, data_dir=None):
                     ValidationIssue(
                         field="source_iscc",
                         message=f"No file in the data directory matches the recorded "
-                        f"source ISCC for {label}. The data does not match the config.",
+                        f"source ISCC for {desc}. The data does not match the config.",
                     )
                 )
         else:
@@ -244,7 +312,7 @@ def verify_config(config, conn=None, data_dir=None):
                 errors.append(
                     ValidationIssue(
                         field="source_iscc",
-                        message=f"Source ISCC mismatch for {label}: config records "
+                        message=f"Source ISCC mismatch for {desc}: config records "
                         f"{annotation.source_iscc}, OMERO now yields {actual}.",
                     )
                 )
@@ -260,7 +328,7 @@ def verify_config(config, conn=None, data_dir=None):
                 warnings.append(
                     ValidationIssue(
                         field="label_iscc",
-                        message=f"No label ISCC stored for {label}; mask not verifiable.",
+                        message=f"No label ISCC stored for {desc}; mask not verifiable.",
                     )
                 )
             continue
@@ -271,7 +339,7 @@ def verify_config(config, conn=None, data_dir=None):
                     ValidationIssue(
                         field="label_iscc",
                         message=f"No file in the data directory matches the recorded "
-                        f"label ISCC for {label}. The mask does not match the config.",
+                        f"label ISCC for {desc}. The mask does not match the config.",
                     )
                 )
         elif annotation.label_id is not None:
@@ -283,7 +351,7 @@ def verify_config(config, conn=None, data_dir=None):
                 errors.append(
                     ValidationIssue(
                         field="label_iscc",
-                        message=f"Label ISCC mismatch for {label}: config records "
+                        message=f"Label ISCC mismatch for {desc}: config records "
                         f"{annotation.label_iscc}, OMERO now yields {actual}.",
                     )
                 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -997,3 +997,105 @@ class TestTrainingConfigWarnings:
                 validation_fraction=0.4,
                 test_fraction=0.0,
             )
+
+
+@pytest.mark.unit
+class TestIsccProvenanceFields:
+    """source_iscc / label_iscc round-trip and iscc_mode toggle."""
+
+    def test_iscc_fields_default_to_none(self):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        ann = ImageAnnotation(image_id=1, image_name="a.tif")
+
+        assert ann.source_iscc is None
+        assert ann.label_iscc is None
+
+    def test_iscc_mode_defaults_to_off(self):
+        from omero_annotate_ai.core.annotation_config import create_default_config
+
+        assert create_default_config().iscc_mode == "off"
+
+    def test_schema_version_bumped(self):
+        from omero_annotate_ai.core.annotation_config import create_default_config
+
+        assert create_default_config().schema_version == "2.1.0"
+
+    def test_old_schema_config_still_loads(self):
+        """2.0.0 configs predate the ISCC fields; they must still load, unstamped."""
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        ann = ImageAnnotation(image_id=1, image_name="a.tif")
+
+        assert ann.source_iscc is None
+
+    def test_iscc_fields_survive_yaml_round_trip(self, tmp_path):
+        from omero_annotate_ai.core.annotation_config import (
+            AnnotationConfig,
+            ImageAnnotation,
+            create_default_config,
+        )
+
+        config = create_default_config()
+        config.iscc_mode = "on"
+        config.add_annotation(
+            ImageAnnotation(
+                image_id=1,
+                image_name="a.tif",
+                source_iscc="ISCC:SOURCE",
+                label_iscc="ISCC:LABEL",
+            )
+        )
+
+        path = tmp_path / "config.yaml"
+        config.save_yaml(path)
+        loaded = AnnotationConfig.from_yaml(path)
+
+        assert loaded.iscc_mode == "on"
+        assert loaded.annotations[0].source_iscc == "ISCC:SOURCE"
+        assert loaded.annotations[0].label_iscc == "ISCC:LABEL"
+
+    def test_iscc_fields_survive_dataframe_round_trip(self):
+        from omero_annotate_ai.core.annotation_config import (
+            ImageAnnotation,
+            create_default_config,
+        )
+
+        config = create_default_config()
+        config.add_annotation(
+            ImageAnnotation(
+                image_id=1,
+                image_name="a.tif",
+                source_iscc="ISCC:SOURCE",
+                label_iscc="ISCC:LABEL",
+            )
+        )
+
+        df = config.to_dataframe()
+        assert df.loc[0, "source_iscc"] == "ISCC:SOURCE"
+        assert df.loc[0, "label_iscc"] == "ISCC:LABEL"
+
+        reloaded = create_default_config()
+        reloaded.from_dataframe(df)
+
+        assert reloaded.annotations[0].source_iscc == "ISCC:SOURCE"
+        assert reloaded.annotations[0].label_iscc == "ISCC:LABEL"
+
+    def test_absent_codes_round_trip_as_none(self):
+        """An unstamped annotation must come back as None, not the string 'None'."""
+        from omero_annotate_ai.core.annotation_config import (
+            ImageAnnotation,
+            create_default_config,
+        )
+
+        config = create_default_config()
+        config.add_annotation(ImageAnnotation(image_id=1, image_name="a.tif"))
+
+        df = config.to_dataframe()
+        assert df.loc[0, "source_iscc"] == "None"
+
+        reloaded = create_default_config()
+        reloaded.from_dataframe(df)
+
+        assert reloaded.annotations[0].source_iscc is None
+        assert reloaded.annotations[0].label_iscc is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -188,13 +188,22 @@ class TestAnnotationConfig:
         YAML template with the expected content.
         """
         template = get_config_template()
-        
+
         assert isinstance(template, str)
         assert "name:" in template
-        
+
         # Test that template is valid YAML
         parsed = yaml.safe_load(template)
         assert isinstance(parsed, dict)
+
+        # Test that the template actually constructs a valid AnnotationConfig.
+        # A YAML-parses-to-a-dict check alone is not enough: YAML 1.1 parses a
+        # bare `off` as the boolean False, which yaml.safe_load happily
+        # accepts but AnnotationConfig rejects (iscc_mode is a Literal["off",
+        # "on"] string). This assertion is what actually catches that class
+        # of bug.
+        config = AnnotationConfig(**parsed)
+        assert config.iscc_mode == "off"
 
 
 @pytest.mark.unit
@@ -1022,12 +1031,30 @@ class TestIsccProvenanceFields:
         assert create_default_config().schema_version == "2.1.0"
 
     def test_old_schema_config_still_loads(self):
-        """2.0.0 configs predate the ISCC fields; they must still load, unstamped."""
-        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+        """A 2.0.0 config predates the ISCC keys entirely; it must still load."""
+        from omero_annotate_ai.core.annotation_config import (
+            AnnotationConfig,
+            ImageAnnotation,
+            create_default_config,
+        )
 
-        ann = ImageAnnotation(image_id=1, image_name="a.tif")
+        config = create_default_config()
+        config.add_annotation(ImageAnnotation(image_id=1, image_name="a.tif"))
 
-        assert ann.source_iscc is None
+        # Shape a genuine pre-2.1.0 config: the ISCC keys did not exist at all,
+        # so remove them rather than setting them to None.
+        old = config.model_dump()
+        old["schema_version"] = "2.0.0"
+        del old["iscc_mode"]
+        for annotation in old["annotations"]:
+            del annotation["source_iscc"]
+            del annotation["label_iscc"]
+
+        loaded = AnnotationConfig(**old)
+
+        assert loaded.iscc_mode == "off"
+        assert loaded.annotations[0].source_iscc is None
+        assert loaded.annotations[0].label_iscc is None
 
     def test_iscc_fields_survive_yaml_round_trip(self, tmp_path):
         from omero_annotate_ai.core.annotation_config import (

--- a/tests/test_omero_functions.py
+++ b/tests/test_omero_functions.py
@@ -647,3 +647,31 @@ class TestGeoJSONPersistence:
         new["channel_presentation"][0]["contrast_end"] = 999
         merged = merge_geojson_patches(existing, new)
         assert merged["channel_presentation"][0]["contrast_end"] == 999
+
+
+@pytest.mark.unit
+class TestIsccColumnTyping:
+    """_prepare_dataframe_for_omero() types the ISCC columns as strings."""
+
+    def test_iscc_columns_typed_as_string(self):
+        import pandas as pd
+
+        from omero_annotate_ai.omero.omero_functions import _prepare_dataframe_for_omero
+
+        df = pd.DataFrame(
+            {
+                "image_id": [1, 2],
+                "source_iscc": ["ISCC:SOURCE", None],
+                "label_iscc": [None, "ISCC:LABEL"],
+            }
+        )
+
+        result = _prepare_dataframe_for_omero(df)
+
+        assert result["source_iscc"].tolist() == ["ISCC:SOURCE", "None"]
+        assert result["label_iscc"].tolist() == ["None", "ISCC:LABEL"]
+        # pandas >=3.0 defaults `.astype(str)` to its dedicated StringDtype rather
+        # than `object` (same as the pre-existing id_columns/datetime_columns
+        # blocks in _prepare_dataframe_for_omero) - assert on the semantic
+        # "string dtype" property so the test holds across pandas versions.
+        assert pd.api.types.is_string_dtype(result["source_iscc"])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1420,3 +1420,56 @@ class TestCellposeMultiChannelSaving:
         saved_train = tifffile.imread(str(train_file))
         assert saved_train.ndim == 3, f"training_input should be 3D (Y,X,C), got shape {saved_train.shape}"
         assert saved_train.shape == (h, w, 1)
+
+
+@pytest.mark.unit
+class TestIsccPipelineHook:
+    """The pipeline stamps provenance only when iscc_mode is on."""
+
+    def test_stamp_not_called_when_mode_off(self, monkeypatch):
+        from omero_annotate_ai.core import annotation_pipeline
+        from omero_annotate_ai.core.annotation_config import create_default_config
+
+        called = []
+        monkeypatch.setattr(
+            annotation_pipeline, "stamp_config", lambda c, conn: called.append(c)
+        )
+
+        config = create_default_config()
+        config.iscc_mode = "off"
+        pipeline = annotation_pipeline.AnnotationPipeline(config, MagicMock())
+        pipeline._stamp_provenance()
+
+        assert called == []
+
+    def test_stamp_called_when_mode_on(self, monkeypatch):
+        from omero_annotate_ai.core import annotation_pipeline
+        from omero_annotate_ai.core.annotation_config import create_default_config
+
+        called = []
+        monkeypatch.setattr(
+            annotation_pipeline, "stamp_config", lambda c, conn: called.append(c)
+        )
+
+        config = create_default_config()
+        config.iscc_mode = "on"
+        pipeline = annotation_pipeline.AnnotationPipeline(config, MagicMock())
+        pipeline._stamp_provenance()
+
+        assert len(called) == 1
+
+    def test_stamp_failure_never_breaks_the_run(self, monkeypatch):
+        """Provenance is best-effort. A failure here must not lose annotations."""
+        from omero_annotate_ai.core import annotation_pipeline
+        from omero_annotate_ai.core.annotation_config import create_default_config
+
+        def boom(config, conn):
+            raise RuntimeError("iscc exploded")
+
+        monkeypatch.setattr(annotation_pipeline, "stamp_config", boom)
+
+        config = create_default_config()
+        config.iscc_mode = "on"
+        pipeline = annotation_pipeline.AnnotationPipeline(config, MagicMock())
+
+        pipeline._stamp_provenance()  # must not raise

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1473,3 +1473,59 @@ class TestIsccPipelineHook:
         pipeline = annotation_pipeline.AnnotationPipeline(config, MagicMock())
 
         pipeline._stamp_provenance()  # must not raise
+
+
+@pytest.mark.unit
+class TestIsccTableRewrite:
+    """_finalize_workflow must mirror stamped codes into the OMERO tracking
+    table, not just config.yaml - otherwise a later resume (which rebuilds
+    config.annotations FROM the table) silently wipes the codes back out."""
+
+    def _make_pipeline(self, iscc_mode="on", read_only=False):
+        from omero_annotate_ai.core import annotation_pipeline
+        from omero_annotate_ai.core.annotation_config import create_default_config
+
+        config = create_default_config()
+        config.iscc_mode = iscc_mode
+        config.workflow.read_only_mode = read_only
+        pipeline = annotation_pipeline.AnnotationPipeline(config, MagicMock())
+        # Isolate _finalize_workflow from unrelated I/O.
+        pipeline._stamp_provenance = Mock()
+        pipeline._auto_save_config = Mock()
+        pipeline._upload_annotation_config_to_omero = Mock()
+        pipeline._replace_omero_table_from_config = Mock()
+        return pipeline
+
+    def test_table_rewritten_when_mode_on(self):
+        pipeline = self._make_pipeline(iscc_mode="on", read_only=False)
+
+        pipeline._finalize_workflow(processed_count=3)
+
+        pipeline._replace_omero_table_from_config.assert_called_once()
+
+    def test_table_not_rewritten_when_mode_off(self):
+        pipeline = self._make_pipeline(iscc_mode="off", read_only=False)
+
+        pipeline._finalize_workflow(processed_count=3)
+
+        pipeline._replace_omero_table_from_config.assert_not_called()
+
+    def test_table_not_rewritten_in_read_only_mode(self):
+        pipeline = self._make_pipeline(iscc_mode="on", read_only=True)
+
+        pipeline._finalize_workflow(processed_count=3)
+
+        pipeline._replace_omero_table_from_config.assert_not_called()
+
+    def test_table_rewrite_failure_does_not_propagate(self):
+        """A raising table write must not break workflow finalization -
+        provenance must never harm an annotation run."""
+        pipeline = self._make_pipeline(iscc_mode="on", read_only=False)
+        pipeline._replace_omero_table_from_config.side_effect = RuntimeError(
+            "OMERO table write exploded"
+        )
+
+        pipeline._finalize_workflow(processed_count=3)  # must not raise
+
+        pipeline._replace_omero_table_from_config.assert_called_once()
+        pipeline._auto_save_config.assert_called_once()

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,97 @@
+"""Tests for ISCC content provenance (processing/provenance.py)."""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from omero_annotate_ai.processing import provenance
+
+
+@pytest.fixture
+def fake_iscc(monkeypatch):
+    """Inject a stub iscc_bio module and hand back its biocode mock.
+
+    provenance.py imports iscc_bio lazily inside functions, so patching
+    sys.modules is enough - no real install needed.
+    """
+    biocode = MagicMock(
+        return_value=[{"iscc_code": "ISCC:AAA", "units": ["ISCC:D", "ISCC:I"]}]
+    )
+    api_mod = types.ModuleType("iscc_bio.api")
+    api_mod.biocode = biocode
+    root_mod = types.ModuleType("iscc_bio")
+    root_mod.api = api_mod
+    monkeypatch.setitem(sys.modules, "iscc_bio", root_mod)
+    monkeypatch.setitem(sys.modules, "iscc_bio.api", api_mod)
+    return biocode
+
+
+@pytest.fixture
+def no_iscc(monkeypatch):
+    """Make `import iscc_bio` raise ImportError, simulating it not installed."""
+    monkeypatch.setitem(sys.modules, "iscc_bio", None)
+
+
+@pytest.mark.unit
+class TestIsccAvailability:
+    """Guarded-import behaviour."""
+
+    def test_available_when_installed(self, fake_iscc):
+        assert provenance.iscc_available() is True
+
+    def test_unavailable_when_missing(self, no_iscc):
+        assert provenance.iscc_available() is False
+
+
+@pytest.mark.unit
+class TestComputeFileIscc:
+    """compute_file_iscc()."""
+
+    def test_returns_code_for_file(self, fake_iscc, tmp_path):
+        img = tmp_path / "image.tif"
+        img.write_bytes(b"fake")
+
+        assert provenance.compute_file_iscc(img) == "ISCC:AAA"
+        fake_iscc.assert_called_once_with(source=str(img))
+
+    def test_returns_none_when_iscc_missing(self, no_iscc, tmp_path):
+        img = tmp_path / "image.tif"
+        img.write_bytes(b"fake")
+
+        assert provenance.compute_file_iscc(img) is None
+
+    def test_returns_none_on_compute_error(self, fake_iscc, tmp_path):
+        fake_iscc.side_effect = RuntimeError("unreadable")
+        img = tmp_path / "image.tif"
+        img.write_bytes(b"fake")
+
+        assert provenance.compute_file_iscc(img) is None
+
+    def test_returns_none_on_empty_result(self, fake_iscc, tmp_path):
+        fake_iscc.return_value = []
+        img = tmp_path / "image.tif"
+        img.write_bytes(b"fake")
+
+        assert provenance.compute_file_iscc(img) is None
+
+
+@pytest.mark.unit
+class TestComputeImageIscc:
+    """compute_image_iscc() - the canonical source-side code, from raw OMERO pixels."""
+
+    def test_returns_code_for_omero_image(self, fake_iscc):
+        conn = MagicMock()
+
+        assert provenance.compute_image_iscc(conn, 123) == "ISCC:AAA"
+        fake_iscc.assert_called_once_with(conn=conn, iid=123)
+
+    def test_returns_none_when_iscc_missing(self, no_iscc):
+        assert provenance.compute_image_iscc(MagicMock(), 123) is None
+
+    def test_returns_none_on_omero_error(self, fake_iscc):
+        fake_iscc.side_effect = RuntimeError("connection lost")
+
+        assert provenance.compute_image_iscc(MagicMock(), 123) is None

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -283,6 +283,83 @@ class TestVerifyConfigArguments:
 
 
 @pytest.mark.unit
+class TestVerifyConfigRequiresIscc:
+    """verify_config() must refuse to give a verdict without iscc-bio.
+
+    Without the library, compute_file_iscc/compute_image_iscc always return
+    None, which would otherwise make every stored code look "absent from the
+    data" - a false mismatch error for every image. A verdict that cannot be
+    backed up must never be returned; this must raise instead, in BOTH modes.
+    """
+
+    def test_raises_in_conn_mode_when_iscc_missing(self, no_iscc):
+        config = _config_with([])
+
+        with pytest.raises(RuntimeError, match="iscc-bio is not installed"):
+            provenance.verify_config(config, conn=MagicMock())
+
+    def test_raises_in_data_dir_mode_when_iscc_missing(self, no_iscc, tmp_path):
+        config = _config_with([])
+
+        with pytest.raises(RuntimeError, match="iscc-bio is not installed"):
+            provenance.verify_config(config, data_dir=tmp_path)
+
+
+@pytest.mark.unit
+class TestScanDirectoryCodes:
+    """_scan_directory_codes() - the offline content scan itself."""
+
+    def test_zarr_store_is_coded_as_a_single_unit(self, fake_iscc, tmp_path):
+        """An OME-Zarr store is a DIRECTORY, not a file - '.zarr' must still match."""
+        zarr_dir = tmp_path / "image.zarr"
+        zarr_dir.mkdir()
+        (zarr_dir / ".zattrs").write_text("{}")
+
+        codes, failed = provenance._scan_directory_codes(tmp_path)
+
+        assert codes == {"ISCC:AAA"}
+        assert failed == []
+        fake_iscc.assert_called_once_with(source=str(zarr_dir))
+
+    def test_does_not_descend_into_a_matched_zarr_store(self, fake_iscc, tmp_path):
+        """A zarr store can hold tens of thousands of chunks; walking them is
+        pointless once the store itself has been coded as a unit."""
+        zarr_dir = tmp_path / "image.zarr"
+        zarr_dir.mkdir()
+        inner = zarr_dir / "0"
+        inner.mkdir()
+        # Would itself match the file-suffix filter if the walk incorrectly
+        # recursed into the zarr store's internals.
+        (inner / "chunk.tif").write_bytes(b"chunk")
+
+        codes, failed = provenance._scan_directory_codes(tmp_path)
+
+        assert codes == {"ISCC:AAA"}
+        assert failed == []
+        fake_iscc.assert_called_once_with(source=str(zarr_dir))
+
+    def test_unreadable_file_is_reported_as_failed_not_silently_dropped(
+        self, fake_iscc, tmp_path
+    ):
+        good = tmp_path / "good.tif"
+        good.write_bytes(b"fake")
+        bad = tmp_path / "bad.tif"
+        bad.write_bytes(b"fake")
+
+        def flaky(source=None, **kwargs):
+            if source == str(bad):
+                raise RuntimeError("corrupt")
+            return [{"iscc_code": "ISCC:AAA"}]
+
+        fake_iscc.side_effect = flaky
+
+        codes, failed = provenance._scan_directory_codes(tmp_path)
+
+        assert codes == {"ISCC:AAA"}
+        assert failed == [bad]
+
+
+@pytest.mark.unit
 class TestVerifyConfigOffline:
     """data_dir mode - the recipient's story. No OMERO connection at all."""
 
@@ -351,6 +428,50 @@ class TestVerifyConfigOffline:
 
         assert result.is_valid is False
         assert any("label_iscc" in e.field for e in result.errors)
+
+    def test_zarr_store_matches_stored_source_code(self, fake_iscc, tmp_path):
+        """OME-Zarr is the headline format-independence case for this feature."""
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        zarr_dir = tmp_path / "published.zarr"
+        zarr_dir.mkdir()
+        (zarr_dir / ".zattrs").write_text("{}")
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        result = provenance.verify_config(config, data_dir=tmp_path)
+
+        assert result.is_valid is True
+        assert result.errors == []
+
+    def test_unreadable_file_produces_a_warning_not_a_mismatch_error(
+        self, fake_iscc, tmp_path
+    ):
+        """A file we could not read must not masquerade as tampered data."""
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        good = tmp_path / "good.tif"
+        good.write_bytes(b"fake")
+        bad = tmp_path / "bad.tif"
+        bad.write_bytes(b"fake")
+
+        def flaky(source=None, **kwargs):
+            if source == str(bad):
+                raise RuntimeError("corrupt")
+            return [{"iscc_code": "ISCC:AAA"}]
+
+        fake_iscc.side_effect = flaky
+
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        result = provenance.verify_config(config, data_dir=tmp_path)
+
+        assert result.is_valid is True
+        assert result.errors == []
+        assert any("bad.tif" in w.message for w in result.warnings)
 
 
 @pytest.mark.unit

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -263,3 +263,120 @@ class TestStampConfig:
 
         assert config.annotations[0].source_iscc is None
         assert config.annotations[1].source_iscc == "ISCC:OK"
+
+
+@pytest.mark.unit
+class TestVerifyConfigArguments:
+    """verify_config() demands exactly one source of truth."""
+
+    def test_rejects_neither_conn_nor_data_dir(self, fake_iscc):
+        config = _config_with([])
+
+        with pytest.raises(ValueError, match="exactly one"):
+            provenance.verify_config(config)
+
+    def test_rejects_both_conn_and_data_dir(self, fake_iscc, tmp_path):
+        config = _config_with([])
+
+        with pytest.raises(ValueError, match="exactly one"):
+            provenance.verify_config(config, conn=MagicMock(), data_dir=tmp_path)
+
+
+@pytest.mark.unit
+class TestVerifyConfigOffline:
+    """data_dir mode - the recipient's story. No OMERO connection at all."""
+
+    def test_match_when_published_file_carries_the_stored_code(
+        self, fake_iscc, tmp_path
+    ):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        (tmp_path / "published.tif").write_bytes(b"fake")
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        result = provenance.verify_config(config, data_dir=tmp_path)
+
+        assert result.is_valid is True
+        assert result.errors == []
+
+    def test_mismatch_when_stored_code_absent_from_data(self, fake_iscc, tmp_path):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        (tmp_path / "published.tif").write_bytes(b"fake")
+        config = _config_with(
+            [
+                ImageAnnotation(
+                    image_id=7, image_name="a.tif", source_iscc="ISCC:DIFFERENT"
+                )
+            ]
+        )
+
+        result = provenance.verify_config(config, data_dir=tmp_path)
+
+        assert result.is_valid is False
+        assert len(result.errors) == 1
+        assert "source_iscc" in result.errors[0].field
+
+    def test_missing_is_a_warning_not_an_error(self, fake_iscc, tmp_path):
+        """No stored code is absence of evidence, not evidence of tampering."""
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        (tmp_path / "published.tif").write_bytes(b"fake")
+        config = _config_with([ImageAnnotation(image_id=7, image_name="a.tif")])
+
+        result = provenance.verify_config(config, data_dir=tmp_path)
+
+        assert result.is_valid is True
+        assert result.errors == []
+        assert len(result.warnings) == 1
+
+    def test_label_code_also_verified(self, fake_iscc, tmp_path):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        (tmp_path / "mask.tif").write_bytes(b"fake")
+        config = _config_with(
+            [
+                ImageAnnotation(
+                    image_id=7,
+                    image_name="a.tif",
+                    source_iscc="ISCC:AAA",
+                    label_iscc="ISCC:NOTPRESENT",
+                )
+            ]
+        )
+
+        result = provenance.verify_config(config, data_dir=tmp_path)
+
+        assert result.is_valid is False
+        assert any("label_iscc" in e.field for e in result.errors)
+
+
+@pytest.mark.unit
+class TestVerifyConfigOmero:
+    """conn mode - the author's own check against the live server."""
+
+    def test_match_when_omero_still_has_the_same_pixels(self, fake_iscc):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        result = provenance.verify_config(config, conn=MagicMock())
+
+        assert result.is_valid is True
+
+    def test_mismatch_when_omero_pixels_changed(self, fake_iscc):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        fake_iscc.return_value = [{"iscc_code": "ISCC:CHANGED"}]
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        result = provenance.verify_config(config, conn=MagicMock())
+
+        assert result.is_valid is False
+        assert len(result.errors) == 1

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -2,7 +2,6 @@
 
 import sys
 import types
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -95,3 +94,73 @@ class TestComputeImageIscc:
         fake_iscc.side_effect = RuntimeError("connection lost")
 
         assert provenance.compute_image_iscc(MagicMock(), 123) is None
+
+
+@pytest.mark.unit
+class TestComputeLabelIscc:
+    """compute_label_iscc() - content code for annotation masks."""
+
+    def test_returns_code_for_label(self, fake_iscc, monkeypatch, tmp_path):
+        """Happy path: fetches mask file and computes ISCC."""
+        # Mock ezomero.get_file_annotation to return a path
+        mask_file = tmp_path / "mask.tif"
+        mask_file.write_bytes(b"fake")
+
+        get_file_annotation = MagicMock(return_value=str(mask_file))
+
+        ezomero_mod = types.ModuleType("ezomero")
+        ezomero_mod.get_file_annotation = get_file_annotation
+        monkeypatch.setitem(sys.modules, "ezomero", ezomero_mod)
+
+        conn = MagicMock()
+        result = provenance.compute_label_iscc(conn, 456)
+
+        assert result == "ISCC:AAA"
+        get_file_annotation.assert_called_once()
+        # Verify it was called with correct arguments
+        call_args = get_file_annotation.call_args
+        assert call_args[0][0] is conn
+        assert call_args[0][1] == 456
+
+    def test_returns_none_when_iscc_missing(self, no_iscc, monkeypatch):
+        """With no_iscc fixture, returns None and does NOT download."""
+        get_file_annotation = MagicMock()
+
+        ezomero_mod = types.ModuleType("ezomero")
+        ezomero_mod.get_file_annotation = get_file_annotation
+        monkeypatch.setitem(sys.modules, "ezomero", ezomero_mod)
+
+        conn = MagicMock()
+        result = provenance.compute_label_iscc(conn, 456)
+
+        assert result is None
+        # Verify ezomero was NOT called (guarded-import short-circuit)
+        get_file_annotation.assert_not_called()
+
+    def test_returns_none_when_mask_path_is_none(self, fake_iscc, monkeypatch):
+        """When ezomero returns None, returns None."""
+        get_file_annotation = MagicMock(return_value=None)
+
+        ezomero_mod = types.ModuleType("ezomero")
+        ezomero_mod.get_file_annotation = get_file_annotation
+        monkeypatch.setitem(sys.modules, "ezomero", ezomero_mod)
+
+        conn = MagicMock()
+        result = provenance.compute_label_iscc(conn, 456)
+
+        assert result is None
+        get_file_annotation.assert_called_once()
+
+    def test_returns_none_on_ezomero_error(self, fake_iscc, monkeypatch):
+        """When ezomero raises, returns None and does not propagate."""
+        get_file_annotation = MagicMock(side_effect=RuntimeError("download failed"))
+
+        ezomero_mod = types.ModuleType("ezomero")
+        ezomero_mod.get_file_annotation = get_file_annotation
+        monkeypatch.setitem(sys.modules, "ezomero", ezomero_mod)
+
+        conn = MagicMock()
+        result = provenance.compute_label_iscc(conn, 456)
+
+        assert result is None
+        get_file_annotation.assert_called_once()

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -475,6 +475,74 @@ class TestVerifyConfigOffline:
 
 
 @pytest.mark.unit
+class TestVerifyConfigDataDirEdgeCases:
+    """data_dir mode must never turn 'nothing found' into a tampering verdict.
+
+    Zero codes scanned means every stored code would otherwise fall into the
+    "not in available_codes" branch and be reported as a mismatch error -
+    even though the data may be perfectly fine and simply wasn't found
+    (wrong path, empty dir, no recognised suffixes, or data_dir being the
+    .zarr store root itself rather than its parent).
+    """
+
+    def test_nonexistent_path_raises_value_error(self, fake_iscc, tmp_path):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        missing = tmp_path / "does_not_exist"
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        with pytest.raises(ValueError, match="does not exist"):
+            provenance.verify_config(config, data_dir=missing)
+
+    def test_empty_directory_raises_runtime_error(self, fake_iscc, tmp_path):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        with pytest.raises(RuntimeError, match="cannot verify"):
+            provenance.verify_config(config, data_dir=empty_dir)
+
+    def test_directory_with_no_recognised_suffixes_raises_runtime_error(
+        self, fake_iscc, tmp_path
+    ):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        (tmp_path / "readme.txt").write_text("not an image")
+        (tmp_path / "notes.json").write_text("{}")
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        with pytest.raises(RuntimeError, match="cannot verify"):
+            provenance.verify_config(config, data_dir=tmp_path)
+
+    def test_data_dir_pointing_directly_at_zarr_root_still_verifies(
+        self, fake_iscc, tmp_path
+    ):
+        """data_dir may BE the .zarr store, not a parent folder containing it."""
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        zarr_root = tmp_path / "published.zarr"
+        zarr_root.mkdir()
+        (zarr_root / ".zattrs").write_text("{}")
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:AAA")]
+        )
+
+        result = provenance.verify_config(config, data_dir=zarr_root)
+
+        assert result.is_valid is True
+        assert result.errors == []
+        fake_iscc.assert_called_once_with(source=str(zarr_root))
+
+
+@pytest.mark.unit
 class TestVerifyConfigOmero:
     """conn mode - the author's own check against the live server."""
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -164,3 +164,102 @@ class TestComputeLabelIscc:
 
         assert result is None
         get_file_annotation.assert_called_once()
+
+
+def _config_with(annotations):
+    """Build a default config carrying the given annotations."""
+    from omero_annotate_ai.core.annotation_config import create_default_config
+
+    config = create_default_config()
+    for ann in annotations:
+        config.add_annotation(ann)
+    return config
+
+
+@pytest.mark.unit
+class TestStampConfig:
+    """stamp_config() fills codes, and codes each unique id exactly once."""
+
+    def test_fills_source_and_label_codes(self, fake_iscc, monkeypatch):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        monkeypatch.setattr(provenance, "compute_label_iscc", lambda conn, lid: "ISCC:LBL")
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", label_id=99)]
+        )
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert config.annotations[0].source_iscc == "ISCC:AAA"
+        assert config.annotations[0].label_iscc == "ISCC:LBL"
+
+    def test_codes_each_source_image_only_once(self, fake_iscc):
+        """Three patches of one image must trigger exactly one OMERO compute."""
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        config = _config_with(
+            [
+                ImageAnnotation(image_id=7, image_name="a.tif", is_patch=True, patch_x=0),
+                ImageAnnotation(image_id=7, image_name="a.tif", is_patch=True, patch_x=1),
+                ImageAnnotation(image_id=7, image_name="a.tif", is_patch=True, patch_x=2),
+            ]
+        )
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert fake_iscc.call_count == 1
+        assert all(a.source_iscc == "ISCC:AAA" for a in config.annotations)
+
+    def test_skips_annotations_without_a_label(self, fake_iscc):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        config = _config_with([ImageAnnotation(image_id=7, image_name="a.tif")])
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert config.annotations[0].source_iscc == "ISCC:AAA"
+        assert config.annotations[0].label_iscc is None
+
+    def test_does_not_recompute_existing_codes(self, fake_iscc):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        config = _config_with(
+            [ImageAnnotation(image_id=7, image_name="a.tif", source_iscc="ISCC:OLD")]
+        )
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert config.annotations[0].source_iscc == "ISCC:OLD"
+        assert fake_iscc.call_count == 0
+
+    def test_no_op_and_warns_when_iscc_missing(self, no_iscc, caplog):
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        config = _config_with([ImageAnnotation(image_id=7, image_name="a.tif")])
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert config.annotations[0].source_iscc is None
+        assert "iscc-bio is not installed" in caplog.text
+
+    def test_one_failing_image_does_not_abort_the_pass(self, fake_iscc):
+        """A broken image must not cost us the codes of the healthy ones."""
+        from omero_annotate_ai.core.annotation_config import ImageAnnotation
+
+        def flaky(conn=None, iid=None, **kwargs):
+            if iid == 7:
+                raise RuntimeError("corrupt pixels")
+            return [{"iscc_code": "ISCC:OK"}]
+
+        fake_iscc.side_effect = flaky
+        config = _config_with(
+            [
+                ImageAnnotation(image_id=7, image_name="bad.tif"),
+                ImageAnnotation(image_id=8, image_name="good.tif"),
+            ]
+        )
+
+        provenance.stamp_config(config, MagicMock())
+
+        assert config.annotations[0].source_iscc is None
+        assert config.annotations[1].source_iscc == "ISCC:OK"


### PR DESCRIPTION
## What

Records ISO 24138 (ISCC) pixel-content codes so a published annotation dataset can be verified — including by a third party, **fully offline, with no OMERO access**.

- `source_iscc` — content code of the source image's **raw OMERO pixels**
- `label_iscc` — content code of the annotation mask

Both are `Optional[str]` fields on `ImageAnnotation`, so they serialize into `config.yaml` *and* mirror into the OMERO tracking table from one field addition.

## Why pixel-level, and why not `iscc-sum`

`iscc-sum` hashes **file bytes**, so the same pixels stored as OMERO pixels vs OME-TIFF vs OME-Zarr produce *different* codes — it cannot compare OMERO against a published copy. `iscc-bio`'s IMAGEWALK is **pixel-level** and format-independent, which is the property we need.

But IMAGEWALK is **exact, not transform-invariant**: it packs raw dtype bytes with no bit-depth or intensity canonicalization (it deliberately matches OMERO's own pixel representation bit-for-bit). Consequence that shapes the whole design: our export path rescales intensities (`img * 255/max`) and restacks channels, so **the exported 8-bit training tiles have codes that do not match their sources**. Codes are therefore computed on raw source pixels only. The tiles are ephemeral micro-SAM/CellPose scratch and are never published, so they are never coded.

## API

```python
from omero_annotate_ai.processing.provenance import stamp_config, verify_config

stamp_config(config, conn)                        # idempotent — retrofits an old config.yaml
result = verify_config(config, conn=conn)         # author, against the live server
result = verify_config(config, data_dir="pub/")   # recipient, fully offline, no OMERO
```

Offline verification is **content-addressed**: every image (and `.zarr` store) under `data_dir` is coded, and each stored code must appear in that set. Filenames are never consulted, so renaming a published file does not break verification.

**Three outcomes:** mismatch → error (`is_valid` False); *missing* (never stamped) → **warning**, `is_valid` stays True; match → nothing. Absence of evidence is not evidence of tampering.

**Deliberate asymmetry:** `stamp_config` is best-effort and silent (a failure can never harm an annotation run). `verify_config` **refuses** — it raises rather than returning a verdict it cannot back up (missing library, non-directory `data_dir`, or a scan that finds nothing codeable). An earlier draft returned a result in those cases and reported every image as a *mismatch*, i.e. it accused good data of being tampered with.

## Safety / compatibility

- `iscc-bio` is an **optional** extra (`pip install 'omero-annotate-ai[provenance]'`), pinned `>=0.1,<0.2` — it is PoC software that declares breaking changes may ship at any time. Imported lazily; the package imports and runs fully without it.
- `iscc_mode` defaults to `"off"` → **zero behaviour change** for existing users.
- `schema_version` 2.0.0 → 2.1.0 (minor: both fields default to `None`, and 2.0.0 configs still load).

## Tests

`363 passed, 5 skipped`. Note the tests **mock `iscc-bio`** (it is not installed in CI), so they prove the wiring, not the codes themselves.

## ⚠️ Before anyone relies on this

Real `iscc-bio` is never exercised in CI. The manual checks in the spec should be run first — above all: **export a lossless copy of a source image in a different container format (OME-TIFF → OME-Zarr) and confirm the code matches.** That format-independence is the claim the entire feature rests on. `compute_file_iscc` against an actual `.zarr` *directory* is also untested against the real library.

## Note for reviewers

This branch also starts tracking `CLAUDE.md` (it was gitignored, so nothing written there ever reached the repo). The version committed here carries a **"Folder Layout"** section from concurrent work on `refactor/folder-layout` describing a rename that is not yet on `main` — happy to drop that section from this PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)